### PR TITLE
Demo: CI/CD pipeline with automatic deployment

### DIFF
--- a/contributions/demo/hors-yptu/README.md
+++ b/contributions/demo/hors-yptu/README.md
@@ -5,7 +5,7 @@ Stephan Horsthemke (hors@kth.se)
 Yi-Pei Tu (yptu@kth.se)
 
 In this demo, we want to use kubernetes on AWS(https://aws.amazon.com/eks/) to design a CI/CD pipeline.
-This pipeline connects to git repositories, tests automatically and builds new images in case of successfull tests. New images are automatically deployed in the cluster. Ultimately we want to have a setup in which we only push a change to the master of the repository and, in case the code is alright, the new version will automatically run in the cluster.
+This pipeline connects to git repositories, tests automatically and builds new images in case of successfull tests. New images are automatically deployed in the cluster. Ultimately we want to have a setup in which we only push a change to the master of the repository and, in case the code is alright, the new version will automatically run in the cluster. We will also consider development, testing, and production enviroment to fit the real process in industry.
 
 To reach this we want to first evaluate some CI/CD tools like travis(https://travis-ci.org/) and circleCI (https://circleci.com/) to then create the demo with our favorite solution.
 

--- a/contributions/demo/hors_yptu/README.md
+++ b/contributions/demo/hors_yptu/README.md
@@ -1,4 +1,4 @@
-# CI/CD pipeline with automatic deplyoment 
+# CI/CD pipeline with automatic deployment 
 
 In this demo, we want to use kubernetes on AWS(https://aws.amazon.com/eks/) to design a CI/CD pipeline.
 This pipeline connects to git repositories, tests automatically and builds new images in case of successfull tests. New images are automatically deployed in the cluster. Ultimately we want to have a setup in which we only push a change to the master of the repository and, in case the code is alright, the new version will automatically run in the cluster.

--- a/contributions/demo/hors_yptu/README.md
+++ b/contributions/demo/hors_yptu/README.md
@@ -1,4 +1,4 @@
-#CI/CD pipeline with automatic deplyoment 
+# CI/CD pipeline with automatic deplyoment 
 
 In this demo, we want to use kubernetes on AWS(https://aws.amazon.com/eks/) to design a CI/CD pipeline.
 This pipeline connects to git repositories, tests automatically and builds new images in case of successfull tests. New images are automatically deployed in the cluster. Ultimately we want to have a setup in which we only push a change to the master of the repository and, in case the code is alright, the new version will automatically run in the cluster.

--- a/contributions/demo/hors_yptu/README.md
+++ b/contributions/demo/hors_yptu/README.md
@@ -1,10 +1,10 @@
-A CICD pipeline wiht automatic deplyoment 
+#CI/CD pipeline with automatic deplyoment 
 
-In this demo, we'' use kubernetes on AWS(EC2 or ECS service) to design a CICD pipeline.
-This pipeline includes git repositories management, auto tested before pushing to the cloud, build new image, the server pulls the new images, and finally the images deploys and run container.
-It also incldues the issue about
--Autoscale the pods/containers easily over kubernets
--HTTPS load balancer over kubernetes
+In this demo, we want to use kubernetes on AWS(https://aws.amazon.com/eks/) to design a CI/CD pipeline.
+This pipeline connects to git repositories, tests automatically and builds new images in case of successfull tests. New images are automatically deployed in the cluster. Ultimately we want to have a setup in which we only push a change to the master of the repository and, in case the code is alright, the new version will automatically run in the cluster.
+
+To reach this we want to first evaluate some CI/CD tools like travis(https://travis-ci.org/) and circleCI (https://circleci.com/) to then create the demo with our favorite solution.
+
 
 source:
 https://kubernetes.io/docs/setup/turnkey/aws/

--- a/contributions/demo/hors_yptu/README.md
+++ b/contributions/demo/hors_yptu/README.md
@@ -1,5 +1,9 @@
 # CI/CD pipeline with automatic deployment 
 
+## Group Member
+Stephan Horsthemke (hors@kth.se)
+Yi-Pei Tu (yptu@kth.se)
+
 In this demo, we want to use kubernetes on AWS(https://aws.amazon.com/eks/) to design a CI/CD pipeline.
 This pipeline connects to git repositories, tests automatically and builds new images in case of successfull tests. New images are automatically deployed in the cluster. Ultimately we want to have a setup in which we only push a change to the master of the repository and, in case the code is alright, the new version will automatically run in the cluster.
 

--- a/contributions/demo/hors_yptu/README.md
+++ b/contributions/demo/hors_yptu/README.md
@@ -1,0 +1,11 @@
+A CICD pipeline wiht automatic deplyoment 
+
+In this demo, we'' use kubernetes on AWS(EC2 or ECS service) to design a CICD pipeline.
+This pipeline includes git repositories management, auto tested before pushing to the cloud, build new image, the server pulls the new images, and finally the images deploys and run container.
+It also incldues the issue about
+-Autoscale the pods/containers easily over kubernets
+-HTTPS load balancer over kubernetes
+
+source:
+https://kubernetes.io/docs/setup/turnkey/aws/
+https://kubernetes.io/


### PR DESCRIPTION
Group member:
Stephan Horsthemke (hors@kth.se)
Yi-Pei Tu (yptu@kth.se)

In this demo, we want to use kubernetes on AWS(https://aws.amazon.com/eks/) to design a CI/CD pipeline.
This pipeline connects to git repositories, tests automatically and builds new images in case of successful tests. New images are automatically deployed in the cluster. Ultimately we want to have a setup in which we only push a change to the master of the repository and, in case the code is alright, the new version will automatically run in the cluster.
To reach this we want to first evaluate some CI/CD tools like travis(https://travis-ci.org/) and circleCI (https://circleci.com/) to then create the demo with our favorite solution.

source:
https://kubernetes.io/docs/setup/turnkey/aws/
https://kubernetes.io/
