### PR TITLE
Tutorial suggestion: Code Coverage

### DIFF
--- a/contributions/tutorial/jonasjo5/README.md
+++ b/contributions/tutorial/jonasjo5/README.md
@@ -1,0 +1,21 @@
+## Tutorial suggestion: Code Coverage
+
+### Group members:
+
+Jonas Johansson, jonasjo5@kth.se
+
+### Description
+
+A step-by-step tutorial on how to setup and use a code coverage tool on your Github repository and integrate it with your CI solution. As an example I would suggest covering how to setup a Python or Java/maven project with Codecov or Coveralls. Each solution of course already have some documentation but I have yet to find a tutorial that is thorough and goes through all the steps mentioned below: 
+
+Suggestions:
+
+- A small introduction to code coverage.
+- Prepare the repository (if necessary).
+- Setup the code coverage tool.
+- Integrate the tool with your repository.
+- Integrate the tool with a CI solution.
+- A few examples on how to use the CC-tool.
+- Hopefully I will found some easter eggs to cover when I dive into the topic.
+
+The only problem I see is that I don't know how to make a browser version. Any suggestions on how I could do this or how I could change my topic to be able to make a browser version of my tutorial?

--- a/contributions/tutorial/jonasjo5/README.md
+++ b/contributions/tutorial/jonasjo5/README.md
@@ -11,11 +11,10 @@ A step-by-step tutorial on how to setup and use a code coverage tool on your Git
 Suggestions:
 
 - A small introduction to code coverage.
+- A comparison between existing solutions and a motivation of how the solution covered by the tutorial was chosen.
 - Prepare the repository (if necessary).
 - Setup the code coverage tool.
 - Integrate the tool with your repository.
 - Integrate the tool with a CI solution.
 - A few examples on how to use the CC-tool.
-- Hopefully I will found some easter eggs to cover when I dive into the topic.
-
-The only problem I see is that I don't know how to make a browser version. Any suggestions on how I could do this or how I could change my topic to be able to make a browser version of my tutorial?
+- Hopefully I will find some easter eggs to cover when I dive into the topic.


### PR DESCRIPTION
## Tutorial suggestion: Code Coverage

### Group members:

Jonas Johansson, jonasjo5@kth.se

### Description

A step-by-step tutorial on how to setup and use a code coverage tool on your Github repository and integrate it with your CI solution. As an example I would suggest covering how to setup a Python or Java/maven project with Codecov or Coveralls. Each solution of course already have some documentation but I have yet to find a tutorial that is thorough and goes through all the steps mentioned below: 

Suggestions:

- A small introduction to code coverage.
- A comparison between existing solutions and a motivation of how the solution covered by the tutorial was chosen.
- Prepare the repository (if necessary).
- Setup the code coverage tool.
- Integrate the tool with your repository.
- Integrate the tool with a CI solution.
- A few examples on how to use the CC-tool.
- Hopefully I will find some easter eggs to cover when I dive into the topic.
