### PR TITLE
Add initial COVID19 Proposal: COVID19 info for KTH-data Student

### DIFF
--- a/contributions/covid19/tommysam-jii/README.md
+++ b/contributions/covid19/tommysam-jii/README.md
@@ -1,0 +1,26 @@
+# COVID19 Proposal
+## Members
+Tommy Samuelsson (tommysam@kth.se)
+Johanna Iivanainen (jii@kth.se)
+
+## Topic
+COVID19 info for KTH-data Student
+
+The idéa is to provide a student on KTH with relevant information about changes in courses that are caused by the COVID19 precautions. We will do this by creating a web-app that students can access and se what changes has been made course by course. 
+Three example for tabs / course folders:
+
+### DD2482
+Course information is only available on github. The course no longer has any live lectures. They are only on Zoom, labs is also held on Zoom.
+
+### SF1923/SF1924
+This course has no longer any live lectures, only on Hangouts. The partial exam has NOT been canceled. Instead, it will be held on Canvas.
+
+### DD1368
+The re-exam has not been canceled, but has not yet gotten a replacement. The teacher is concidering replacments, Home-exam or a hand in. 
+
+----
+On top of that it would be some "standard" COVID 19 information like confirmed cases, deaths and recovered.
+
+That hard part would be the infomation gathering. 
+The idea here is to start with submitting the infmation we already know. But also have an open portal for every one to add new course information. 
+So that information pool would be community build. Hopefully it catches on and the teacher will use it directly.


### PR DESCRIPTION
**COVID19 Proposal**
**Members**
Tommy Samuelsson (tommysam@kth.se)
Johanna Iivanainen (jii@kth.se)

**Topic**
COVID19 info for KTH-data Student

The idéa is to provide a student on KTH with relevant information about changes in courses that are caused by the COVID19 precautions. We will do this by creating a web-app that students can access and se what changes has been made course by course. 
Three example for tabs / course folders:

**DD2482**
Course information is only available on github. The course no longer has any live lectures. They are only on Zoom, labs is also held on Zoom.

**SF1923/SF1924**
This course has no longer any live lectures, only on Hangouts. The partial exam has NOT been canceled. Instead, it will be held on Canvas.

**DD1368**
The re-exam has not been canceled, but has not yet gotten a replacement. The teacher is concidering replacments, Home-exam or a hand in. 

**----**
On top of that it would be some "standard" COVID 19 information like confirmed cases, deaths and recovered.

That hard part would be the infomation gathering. 
The idea here is to start with submitting the infmation we already know. But also have an open portal for every one to add new course information. 
So that information pool would be community build. Hopefully it catches on and the teacher will use it directly.