### PR TITLE
Open-source proposal: Wemake Python Styleguide

### DIFF
--- a/contributions/open-source/ruwaid-dstevens/README.md
+++ b/contributions/open-source/ruwaid-dstevens/README.md
@@ -1,13 +1,13 @@
 # Open-source proposal
 ## Members
-Ruwaid Louis (ruwaid@kth.se)
-GitHub: ruwaid4
+Ruwaid Louis (ruwaid@kth.se) </br>
+GitHub: @ruwaid4
 
-David Stevens (dstevens@kth.se)
-Github: stevensdavid
+David Stevens (dstevens@kth.se) </br>
+Github: @stevensdavid
 
 ## Proposal
-Create a new rule for Wemake Python Styleguide along with all of the required tests and get it approved by the maintainer.
+Create a new rule for Wemake Python Styleguide along with all of the required tests and get it approved by the maintainer. </br>
 GitHub Repo: https://github.com/wemake-services/wemake-python-styleguide
 
 ## Description

--- a/contributions/open-source/ruwaid-dstevens/README.md
+++ b/contributions/open-source/ruwaid-dstevens/README.md
@@ -1,0 +1,14 @@
+# Open-source proposal
+## Members
+Ruwaid Louis (ruwaid@kth.se)
+GitHub: ruwaid4
+
+David Stevens (dstevens@kth.se)
+Github: stevensdavid
+
+## Proposal
+Create a new rule for Wemake Python Styleguide along with all of the required tests and get it approved by the maintainer.
+GitHub Repo: https://github.com/wemake-services/wemake-python-styleguide
+
+## Description
+Wemake Python Styleguide strives to be the strictest linter ever. It has an active community in GitHub and is very popular. It is essentially a flake8 plugin making it very easy to use for anyone wanting to put themselves in agony.


### PR DESCRIPTION
# Open-source proposal
## Members
Ruwaid Louis (ruwaid@kth.se)
GitHub: @ruwaid4

David Stevens (dstevens@kth.se)
Github: @stevensdavid

## Proposal
Create a new rule for Wemake Python Styleguide along with all of the required tests and get it approved by the maintainer.
GitHub Repo: https://github.com/wemake-services/wemake-python-styleguide

## Description
Wemake Python Styleguide strives to be the strictest linter ever. It has an active community in GitHub and is very popular. It is essentially a flake8 plugin making it very easy to use for anyone wanting to put themselves in agony.