### PR TITLE
Tutorial proposal: Creating a bot on GitLab

### DIFF
--- a/contributions/tutorial/jadlers-xmas92/README.md
+++ b/contributions/tutorial/jadlers-xmas92/README.md
@@ -1,0 +1,23 @@
+# Tutorial Proposal: Creating a simple bot on GitLab
+
+## Members
+
+- Jacob Adlers (jadlers@kth.se)
+- Axel Boldt-Christmas (axelbc@kth.se) 
+	- Github username: xmas92
+
+## Proposal
+
+GitHub has created the ProBot app in order to make it easy to build a bot connected to your repositories. This feature is not available on Gitlabs and it requires more setup and manual work to get a bot set up. We’ll create a tutorial on katacoda which guides you through the steps necessary to start building your own bot.
+
+Preliminary outline:
+
+1. Create a bot account in self-hosted GitLab.
+2. Configure bot permissions and webhooks for repository
+3. Create simple bot software using API framework GitBeaker
+4. Explore bot <-> GitLab interactions.
+
+## Motivation
+
+Bots can help to automate repetitive tasks in a repository. There are a huge amount of bots created for GitHub and the reason is most likely that it’s very easy to create one. Searching for bots for GitLab gives very few results and by creating a tutorial on how to create one we hope to see the number of bots created increase.
+


### PR DESCRIPTION
# Tutorial Proposal: Creating a simple bot on GitLab

## Members

- Jacob Adlers (jadlers@kth.se)
- Axel Boldt-Christmas (axelbc@kth.se) 
	- Github username: xmas92

## Proposal

GitHub has created the ProBot app in order to make it easy to build a bot connected to your repositories. This feature is not available on Gitlabs and it requires more setup and manual work to get a bot set up. We’ll create a tutorial on katacoda which guides you through the steps necessary to start building your own bot.

Preliminary outline:

1. Create a bot account in self-hosted GitLab.
2. Configure bot permissions and webhooks for repository
3. Create simple bot software using API framework GitBeaker
4. Explore bot <-> GitLab interactions.

## Motivation

Bots can help to automate repetitive tasks in a repository. There are a huge amount of bots created for GitHub and the reason is most likely that it’s very easy to create one. Searching for bots for GitLab gives very few results and by creating a tutorial on how to create one we hope to see the number of bots created increase.