### PR TITLE
Open-source proposal: Upgrade Strongbox documentation to mkdocs-material-5.0.0

### DIFF
--- a/contributions/open-source/adambjo-bratfors/README.md
+++ b/contributions/open-source/adambjo-bratfors/README.md
@@ -1,0 +1,31 @@
+# Open-source proposal: Upgrade Strongbox documentation to mkdocs-material-5.0.0
+
+## Contributors
+
+Adam Björnberg (adambjo@kth.se)
+GitHub: adbjo
+
+Robin Bråtfors (bratfors@kth.se)
+GitHub: rbratfors
+
+
+## Proposal
+
+Migrate the [Strongbox documentation](https://strongbox.github.io/) to Material for MkDocs 5.
+
+Solves this issue: https://github.com/strongbox/strongbox/issues/1715 
+
+## Description
+
+The following tasks will need to be carried out:
+
+- Upgrade our docker image so it uses the latest version ci-build-images/images/mkdocs/Dockerfile.mkdocs and installs the correct pip dependencies
+- Make any necessary configuration changes
+- Add support pymdownx.tabbed in markdown_extensions under mkdocs.yaml (this requires pymdown-extensions>=7.0)
+- Search for todo: pymdownx.tabbed within the project to
+
+## Ties to DevOps
+
+- Strongbox is an **artifact repository** manager
+- Docker image configuration (**containerization**)
+- MkDocs is a **project documentation** generator

--- a/contributions/open-source/adambjo-bratfors/README.md
+++ b/contributions/open-source/adambjo-bratfors/README.md
@@ -19,7 +19,7 @@ Solves this issue: https://github.com/strongbox/strongbox/issues/1715
 
 The following tasks will need to be carried out:
 
-- Upgrade our docker image so it uses the latest version ci-build-images/images/mkdocs/Dockerfile.mkdocs and installs the correct pip dependencies
+- Upgrade docker image so it uses the latest version ci-build-images/images/mkdocs/Dockerfile.mkdocs and installs the correct pip dependencies
 - Make any necessary configuration changes
 - Add support pymdownx.tabbed in markdown_extensions under mkdocs.yaml (this requires pymdown-extensions>=7.0)
 - Search for todo: pymdownx.tabbed within the project to

--- a/contributions/open-source/adambjo-bratfors/README.md
+++ b/contributions/open-source/adambjo-bratfors/README.md
@@ -1,4 +1,4 @@
-# Open-source proposal: Upgrade Strongbox documentation to mkdocs-material-5.0.0
+# Upgrade Strongbox documentation to mkdocs-material-5.0.0
 
 ## Contributors
 


### PR DESCRIPTION
# Upgrade Strongbox documentation to mkdocs-material-5.0.0

## Contributors

Adam Björnberg (adambjo@kth.se)
GitHub: adbjo

Robin Bråtfors (bratfors@kth.se)
GitHub: rbratfors


## Proposal

Migrate the [Strongbox documentation](https://strongbox.github.io/) to Material for MkDocs 5.

Solves this issue: https://github.com/strongbox/strongbox/issues/1715 

## Description

The following tasks will need to be carried out:

- Upgrade docker image so it uses the latest version ci-build-images/images/mkdocs/Dockerfile.mkdocs and installs the correct pip dependencies
- Make any necessary configuration changes
- Add support pymdownx.tabbed in markdown_extensions under mkdocs.yaml (this requires pymdown-extensions>=7.0)
- Search for todo: pymdownx.tabbed within the project to

## Ties to DevOps

- Strongbox is an **artifact repository** manager
- Docker image configuration (**containerization**)
- MkDocs is a **project documentation** generator