### PR TITLE
Demo proposal: Calico policies in Kubernetes

### DIFF
--- a/contributions/demo/bratfors-kasperli/README.md
+++ b/contributions/demo/bratfors-kasperli/README.md
@@ -1,0 +1,13 @@
+# Demo proposal
+
+## Members
+
+Robin Bråtfors (bratfors@kth.se)
+Kasper Liu (kasperli@kth.se)
+
+## Topic
+
+Demo of using Calico policies in Kubernetes
+
+## Details
+Calico is used for network security and source networking for containers and virtual machines. We want to demonstrate how Calico policies can be used in Kubernetes.


### PR DESCRIPTION
# Demo proposal (initial)

## Members

Robin Bråtfors (bratfors@kth.se)
Kasper Liu (kasperli@kth.se)

## Topic

Demo of using Calico policies in Kubernetes

## Details
Calico is used for network security and source networking for containers and virtual machines. We want to demonstrate how Calico policies can be used in Kubernetes.