### PR TITLE
Updated demo proposal: Calico policies in Kubernetes

### DIFF
--- a/contributions/demo/bratfors-kasperli/README.md
+++ b/contributions/demo/bratfors-kasperli/README.md
@@ -7,7 +7,11 @@ Kasper Liu (kasperli@kth.se)
 
 ## Topic
 
-Demo of using Calico policies in Kubernetes
+Demo of using Calico policies in Kubernetes, utilizing the Google Kubernetes Engine.
 
 ## Details
-Calico is used for network security and source networking for containers and virtual machines. We want to demonstrate how Calico policies can be used in Kubernetes.
+Calico is used for network security and source networking for containers and virtual machines. We want to demonstrate how Calico policies can be used in Kubernetes. We will do this using the Google Kubernetes Engine provided on the Google Cloud Platform, we feel that this approach is the most relevant with the increased popularity of Cloud technology.
+
+The demo will (hopefully) include a visual representation of the traffic flow and how the nodes interact depending on their policies.
+
+We plan to screencast the demo and add some voice-over/subtitles.


### PR DESCRIPTION
Initially we wanted to perform the demo locally, but we decided to switch to GKE instead for the reasons stated in the README file.

This is an update of a prior pull request (#605).

Kasper did an essay on cloud, and the technology is featured in this demo (Google Cloud Platform) but the focus will be on container orchestration (Kubernetes and Calico) so we feel that they don't clash.