### PR TITLE
Demo Proposal: Setting up a Google Compute instance with Terraform

### DIFF
--- a/contributions/demo/madon-vals/README.md
+++ b/contributions/demo/madon-vals/README.md
@@ -1,0 +1,8 @@
+# Demo Proposal
+## Members
+Victor Josephson (vals@kth.se).
+Github username: valsen
+Maël Madon (madon@kth.se).
+Github username: Mema5
+## Title
+Use Terraform to setup and run a Google Compute Instance.


### PR DESCRIPTION
# Demo Proposal
## Members
Victor Josephson (vals@kth.se).
Github username: valsen
Maël Madon (madon@kth.se).
Github username: Mema5
## Title
Use Terraform to setup and run a Google Compute Instance.