### PR TITLE
Completed open-source: Wemake Python Styleguide

### DIFF
--- a/contributions/open-source/ruwaid-dstevens/README.md
+++ b/contributions/open-source/ruwaid-dstevens/README.md
@@ -1,4 +1,4 @@
-# Open-source proposal
+# Open-source Submission
 ## Members
 Ruwaid Louis (ruwaid@kth.se) </br>
 GitHub: @ruwaid4
@@ -12,3 +12,6 @@ GitHub Repo: https://github.com/wemake-services/wemake-python-styleguide
 
 ## Description
 Wemake Python Styleguide strives to be the strictest linter ever. It has an active community in GitHub and is very popular. It is essentially a flake8 plugin making it very easy to use for anyone wanting to put themselves in agony.
+
+## Submission Link
+The [PR](https://github.com/wemake-services/wemake-python-styleguide/pull/1315) has been accepted and will eventually be merged in the next version.


### PR DESCRIPTION
# Open-source Submission
## Members
Ruwaid Louis (ruwaid@kth.se) </br>
GitHub: @ruwaid4

David Stevens (dstevens@kth.se) </br>
Github: @stevensdavid

## Proposal
Create a new rule for Wemake Python Styleguide along with all of the required tests and get it approved by the maintainer. </br>
GitHub Repo: https://github.com/wemake-services/wemake-python-styleguide

## Description
Wemake Python Styleguide strives to be the strictest linter ever. It has an active community in GitHub and is very popular. It is essentially a flake8 plugin making it very easy to use for anyone wanting to put themselves in agony.

## Submission Link
The [PR](https://github.com/wemake-services/wemake-python-styleguide/pull/1315) has been accepted and will eventually be merged in the next version.
