### PR TITLE
Added demo URLs

### DIFF
--- a/contributions/demo/cwing/README.md
+++ b/contributions/demo/cwing/README.md
@@ -1,9 +1,9 @@
 
 ## Updated with demo URLs
 
-Screencast URL with easter egg hint: https://youtu.be/H8R7EtumyL8
+Screencast URL with easter egg hint: https://youtu.be/VHttX3IZOhw
 
-Screencast URL with easter egg shown: https://youtu.be/Xd505ZyVmzw
+Screencast URL with easter egg shown: https://youtu.be/XTmD-rRdCK4
 
 Github repo: https://github.com/cwinge/web-terminal
 

--- a/contributions/demo/cwing/README.md
+++ b/contributions/demo/cwing/README.md
@@ -1,7 +1,9 @@
 
 ## Updated with demo URLs
 
-Screencast URL: https://youtu.be/vfoIpUxWGOQ
+Screencast URL with easter egg hint: https://youtu.be/H8R7EtumyL8
+
+Screencast URL with easter egg shown: https://youtu.be/Xd505ZyVmzw
 
 Github repo: https://github.com/cwinge/web-terminal
 

--- a/contributions/demo/cwing/README.md
+++ b/contributions/demo/cwing/README.md
@@ -1,3 +1,12 @@
+
+## Updated with demo URLs
+
+Screencast URL: https://youtu.be/vfoIpUxWGOQ
+
+Github repo: https://github.com/cwinge/web-terminal
+
+----
+
 ## Inspiration behind the demo
 Just as a short background, I figured I'd give the reason I thought of doing this demo.
 
@@ -41,10 +50,3 @@ Could also prepare customized images for demos/presentations needed to be perfor
 
 ### Concerns
 My main concern is how well the free tier services available might be quite detrimental to how responsive the terminals will be, especially with multiple users, but I would not think it is the fault of the idea. Could alternatively publish the website on my own desktop instead of AWS/Azure(will still be how it is done in the actual demo) during the 5th, but will see if it will be needed or not.
-
-----
-## Updated with demo URLs
-
-Screencast URL: https://youtu.be/vfoIpUxWGOQ
-
-Github repo: https://github.com/cwinge/web-terminal

--- a/contributions/demo/cwing/README.md
+++ b/contributions/demo/cwing/README.md
@@ -41,3 +41,10 @@ Could also prepare customized images for demos/presentations needed to be perfor
 
 ### Concerns
 My main concern is how well the free tier services available might be quite detrimental to how responsive the terminals will be, especially with multiple users, but I would not think it is the fault of the idea. Could alternatively publish the website on my own desktop instead of AWS/Azure(will still be how it is done in the actual demo) during the 5th, but will see if it will be needed or not.
+
+----
+## Updated with demo URLs
+
+Screencast URL: https://youtu.be/vfoIpUxWGOQ
+
+Github repo: https://github.com/cwinge/web-terminal


### PR DESCRIPTION
Updated with demo URLs

Screencast URL with easter egg hint: https://youtu.be/VHttX3IZOhw (might be hard to spot due to speed up)

Screencast URL with easter egg shown: https://youtu.be/XTmD-rRdCK4

Github repo: https://github.com/cwinge/web-terminal

URL to the demo will be posted on the 5th as a comment on the pull request. The easter egg can be used with the demo.