### PR TITLE
Update YouTube link for jadlers monitoring demo

### DIFF
--- a/contributions/demo/jadlers/README.md
+++ b/contributions/demo/jadlers/README.md
@@ -21,7 +21,7 @@ displayed.
 
 ## Screencast link
 
-[https://youtu.be/yPdwBRndwPY](https://youtu.be/yPdwBRndwPY)
+[https://youtu.be/BX7Fa_DdlQc](https://youtu.be/BX7Fa_DdlQc)
 
 ## Project repository
 


### PR DESCRIPTION
It was not possible to do the changes pointed out by reviewers (#809) in YouTube-studio for the link to stay the same. I've therefore uploaded a new version and updated the link.

> ## Screencast link
>
> [https://youtu.be/BX7Fa_DdlQc](https://youtu.be/BX7Fa_DdlQc)