### PR TITLE
Repeat Tutorial Complete

### DIFF
--- a/contributions/tutorial/bratfors-kasperli/README.md
+++ b/contributions/tutorial/bratfors-kasperli/README.md
@@ -1,4 +1,4 @@
-# Tutorial Complete: TeamCity
+# Complete Tutorial: TeamCity
 
 ## Group members
 - Robin Bråtfors, bratfors@kth.se
@@ -10,9 +10,6 @@ A tutorial that teaches the reader how to install and setup TeamCity from scratc
 ## Submission
 The tutorial is posted on:
 
-https://medium.com/@kasperliu93/teamcity-tutorial-for-a-gradle-project-21463a62d067
+https://github.com/Kappenn/TeamCity_Tutorial
 
 We have a fun fact in the background section and also an easter egg if one chooses to use the provided repo for the tutorial.
-
-Edit:
-Updated after feedback.


### PR DESCRIPTION
# Tutorial Complete Repeat: TeamCity

## Group members
- Robin Bråtfors, bratfors@kth.se
- Kasper Liu, kasperli@kth.se

## Description
A tutorial that teaches the reader how to install and setup TeamCity from scratch for a gradle project on GitHub. The tutorial will have some screen captures and should be easy to understand for anyone with experience in GitHub, but not necessarily with continuous integration.

## Submission
The tutorial is posted on:

https://github.com/Kappenn/TeamCity_Tutorial

We have a fun fact in the background section and also an easter egg if one chooses to use the provided repo for the tutorial.

## Repeat:

We have removed the tutorial from Medium and now it exist only on github.

We have expanded the background to explain about how CI and automated build tools are connected to Devops and why TeamCity is a good option.

We have added instructions to install Java 8 and Gradle, either from the respective website or through a package manager.