### PR TITLE
Add GitHub action that automatically counts task registrations

### DIFF
--- a/.github/workflows/assignment-statistics.yml
+++ b/.github/workflows/assignment-statistics.yml
@@ -38,5 +38,9 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Update the statistic issue
-        run: python ./tools/stat_submissions.py -p ../attic/2020/contributions-2020 --printInMarkdown --printStudentStat
-          echo test, and deploy your project.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_FULLNAME: ${{ github.repository }}
+          CONTRIBUTIONS_PATH: ${{ secrets.ASSIGNMENT_STAT_CONTRIBUTIONS_PATH }}
+          ISSUE_NUMBER: ${{ secrets.ASSIGNMENT_STAT_ISSUE_NUMBER }}
+        run: python ./tools/stat_submissions.py -p ../attic/2020/contributions-2020 --printInMarkdown --printStudentStat --publish

--- a/.github/workflows/assignment-statistics.yml
+++ b/.github/workflows/assignment-statistics.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
     - "2021"
-    - "assignment-stat-action"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/assignment-statistics.yml
+++ b/.github/workflows/assignment-statistics.yml
@@ -36,6 +36,10 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f ./tools/requirements.txt ]; then pip install -r ./tools/requirements.txt; fi
 
+      # Set timezone to Europe/Stockholm
+      - name: Set timezone
+        run: sudo timedatectl set-timezone Europe/Stockholm
+
       # Runs a single command using the runners shell
       - name: Update the statistic issue
         env:

--- a/.github/workflows/assignment-statistics.yml
+++ b/.github/workflows/assignment-statistics.yml
@@ -16,7 +16,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  count-assignments:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -43,4 +43,4 @@ jobs:
           REPO_FULLNAME: ${{ github.repository }}
           CONTRIBUTIONS_PATH: ${{ secrets.ASSIGNMENT_STAT_CONTRIBUTIONS_PATH }}
           ISSUE_NUMBER: ${{ secrets.ASSIGNMENT_STAT_ISSUE_NUMBER }}
-        run: python ./tools/stat_submissions.py -p ../attic/2020/contributions-2020 --printInMarkdown --printStudentStat --publish
+        run: python ./tools/stat_submissions.py -p $CONTRIBUTIONS_PATH --printInMarkdown --printStudentStat --publish

--- a/.github/workflows/assignment-statistics.yml
+++ b/.github/workflows/assignment-statistics.yml
@@ -6,9 +6,9 @@ name: Statistic Information for Each Assignment Category
 on:
   # Triggers the workflow on push or pull request events but only for the 2021 branch
   push:
-    branches: [ 2021 ]
-  pull_request:
-    branches: [ 2021 ]
+    branches:
+    - "2021"
+    - "assignment-stat-action"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/assignment-statistics.yml
+++ b/.github/workflows/assignment-statistics.yml
@@ -1,0 +1,42 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Statistic Information for Each Assignment Category
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the 2021 branch
+  push:
+    branches: [ 2021 ]
+  pull_request:
+    branches: [ 2021 ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Setup Python
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f ./tools/requirements.txt ]; then pip install -r ./tools/requirements.txt; fi
+
+      # Runs a single command using the runners shell
+      - name: Update the statistic issue
+        run: python ./tools/stat_submissions.py -p ../attic/2020/contributions-2020 --printInMarkdown --printStudentStat
+          echo test, and deploy your project.

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,2 @@
 PTable
+PyGithub

--- a/tools/stat_submissions.py
+++ b/tools/stat_submissions.py
@@ -4,11 +4,18 @@
 
 import sys, os, time, logging
 import getopt
+from github import Github
 from prettytable import PrettyTable
 
 SUBMISSIONS_PATH = ''
 PRINT_STUDENT_STAT = False
 PRINT_IN_MARKDOWN = False
+PUBLISH = False
+
+# ENVs for publishing the results
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+REPO_FULLNAME = os.getenv("REPO_FULLNAME")
+ISSUE_NUMBER = os.getenv("ISSUE_NUMBER")
 
 def main():
     handle_args(sys.argv[1:])
@@ -23,19 +30,38 @@ def main():
                 stat_per_student.update({name:[category]})
             else:
                 stat_per_student[name].append(category)
-    print("*Automatically genereated at %s*"%time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()))
 
-    print("Statistic Information for Each Category")
-    print("")
-    print_stat_category_markdown(stat_per_category) if PRINT_IN_MARKDOWN else print_stat_category(stat_per_category)
-    print("")
+    content = ""
+    content = content + "*Automatically genereated at %s*\n"%time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+
+    content = content + "Statistic Information for Each Category\n"
+
+    if PRINT_IN_MARKDOWN:
+        content = content + get_stat_category_markdown(stat_per_category)
+    else:
+        content = content + get_stat_category(stat_per_category)
 
     if PRINT_STUDENT_STAT:
-        print("Statistic Information for Each Student")
-        print("")
-        print_stat_student_markdown(stat_per_student) if PRINT_IN_MARKDOWN else print_stat_student(stat_per_student)
+        content = content + "\nStatistic Information for Each Student\n"
+        if PRINT_IN_MARKDOWN:
+            content = content + get_stat_student_markdown(stat_per_student)
+        else:
+            content = content + get_stat_student(stat_per_student)
 
-def print_stat_category(stat_info):
+    if PUBLISH:
+        publish_on_issue(content)
+    else:
+        print (content)
+
+def publish_on_issue(content):
+    github = Github(GITHUB_TOKEN)
+    gitrepo = github.get_repo(REPO_FULLNAME)
+    if ISSUE_NUMBER != "" and int(ISSUE_NUMBER) > 0:
+        issue = gitrepo.get_issue(number = int(ISSUE_NUMBER))
+        issue.edit(body = content)
+
+
+def get_stat_category(stat_info):
     stat_table = PrettyTable()
     stat_table.field_names = ["Category name", "Registrations"]
 
@@ -45,20 +71,24 @@ def print_stat_category(stat_info):
         total = total + stat_info[category]["task_count"]
     stat_table.add_row(["TOTAL", total])
 
-    print(stat_table)
+    return stat_table.get_string()
 
-def print_stat_category_markdown(stat_info):
-    print("|Category name | Registrations|")
-    print("|--------------|--------------|")
+def get_stat_category_markdown(stat_info):
+    return_str = """
+|Category name | Registrations|
+|--------------|--------------|
+"""
     total = 0
     for category in stat_info:
-        print("|%s|%s|"%(category, stat_info[category]["task_count"]))
+        return_str = return_str + "|%s|%s|\n"%(category, stat_info[category]["task_count"])
         total = total + stat_info[category]["task_count"]
-    print("|--------------|------------|")
-    print("|TOTAL|%s|"%total)
+    return_str = return_str + "|--------------|------------|\n"
+    return_str = return_str + "|TOTAL|%s|\n"%total
+
+    return return_str
 
 
-def print_stat_student(stat_info):
+def get_stat_student(stat_info):
     stat_table = PrettyTable()
     stat_table.field_names = ["Index", "Student name", "Registrations Count", "Categories"]
 
@@ -73,32 +103,36 @@ def print_stat_student(stat_info):
         if task_count > 4:
             logging.warn("%s's task_count is: %d (> 4)"%(student, task_count))
 
-    print(stat_table)
+    return_str = stat_table.get_string()
 
-    print("")
-    print("Summary")
+    return_str = return_str + "\nSummary\n"
     for count in summary:
-        print("%s students with %s registered tasks: %s"%(len(summary[count]), count, ", ".join(summary[count])))
+        return_str = return_str + "%s students with %s registered tasks: %s\n"%(len(summary[count]), count, ", ".join(summary[count]))
 
-def print_stat_student_markdown(stat_info):
-    print("|Index | Student name | Registrations Count | Categories|")
-    print("|------|--------------|---------------------|-----------|")
+    return return_str
+
+def get_stat_student_markdown(stat_info):
+    return_str = """
+|Index | Student name | Registrations Count | Categories|
+|------|--------------|---------------------|-----------|
+"""
 
     index = 1
     summary = {4:[], 3:[], 2:[], 1:[]}
     for student in stat_info:
         task_count = len(stat_info[student])
-        print("|%s|%s|%s|%s|"%(index, student, task_count, " ".join(stat_info[student])))
+        return_str = return_str + "|%s|%s|%s|%s|\n"%(index, student, task_count, " ".join(stat_info[student]))
         summary[task_count].append(student)
         index = index + 1
 
         # if task_count >= 4:
         #     logging.warn("%s's task_count >= 4"%student)
 
-    print("")
-    print("Summary")
+    return_str = return_str + "\nSummary\n"
     for count in summary:
-        print("**%s students with %s registered tasks:** %s"%(len(summary[count]), count, ", ".join(summary[count])))
+        return_str = return_str + "**%s students with %s registered tasks:** %s\n"%(len(summary[count]), count, ", ".join(summary[count]))
+
+    return return_str
 
 def stat_categories(path):
     categories = dict()
@@ -142,9 +176,10 @@ def handle_args(argv):
     global SUBMISSIONS_PATH
     global PRINT_STUDENT_STAT
     global PRINT_IN_MARKDOWN
+    global PUBLISH
 
     try:
-        opts, args = getopt.getopt(argv, "p:m", ["path=", "printStudentStat", "printInMarkdown", "help"])
+        opts, args = getopt.getopt(argv, "p:m", ["path=", "printStudentStat", "printInMarkdown", "publish", "help"])
     except getopt.GetoptError as error:
         logging.error(error)
         print_help_info()
@@ -160,6 +195,8 @@ def handle_args(argv):
             PRINT_STUDENT_STAT = True
         elif opt in ("-m", "--printInMarkdown"):
             PRINT_IN_MARKDOWN = True
+        elif opt in ("--publish"):
+            PUBLISH = True
 
     if SUBMISSIONS_PATH == '':
         logging.error("You should use -p or --path= to specify the path to students submissions")
@@ -175,6 +212,7 @@ def print_help_info():
     print('optional:')
     print('    --printStudentStat print statistic data per student')
     print('    -m or --printInMarkdown print statistic data in markdown syntax')
+    print('    --publish publish the statistics on an issue')
     print('stat_submissions.py --help to display this help info')
 
 if __name__ == "__main__":


### PR DESCRIPTION
I think somehow I didn't push the python script that publishes registration stats to the repo. So I take this opportunity to make some improvement.

After merging this PR, the `devops-course` will have a GitHub action that automatically updates the issue body about task registrations. In order to do this, two action secrets need to be specified:

For the administrators of this repo, please visit:
https://github.com/KTH/devops-course/settings/secrets/actions

Then create the following repository secrets:

- ASSIGNMENT_STAT_CONTRIBUTIONS_PATH: ./contributions (the path to the contributions folder)
- ASSIGNMENT_STAT_ISSUE_NUMBER: 917 (I have already created this issue)

Now when there is a push event happens in branch 2021, this action will be triggered and the statistics will be updated on the target issue.