### PR TITLE
Course Automation: Checking link validity in the course github text descriptions

### DIFF
--- a/contributions/course-automation/zidi-sihan/README.md
+++ b/contributions/course-automation/zidi-sihan/README.md
@@ -13,5 +13,8 @@ text descriptions, for example, readme files. Because sometimes
 the links might be not accessible or out of date.
 
 
-## Solution
-TODO
+## Proposed solution
+
+After finding a broken link, our idea is:
+- to create a github action and whenever there is a pull request, the action should automatically parse the children or descendant pages under the course website (KTH/devops-course) to find all the broken links
+- to show the detail information (time of when the action find the broken link, the corresponding commit log and who writes this dead link, using git blame maybe) of all the broken links in a list of one issue

--- a/contributions/course-automation/zidi-sihan/README.md
+++ b/contributions/course-automation/zidi-sihan/README.md
@@ -1,0 +1,17 @@
+# Course automation: Checking link validity in the course github text descriptions
+
+## Members
+
+Chen, Zidi: zidi@kth.se, https://github.com/Chen-Zidi
+Chen, Sihan sihanc@kth.se, https://github.com/Spycsh
+
+
+## Proposal
+
+We want to check the validity of the deadlinks in the course github 
+text descriptions, for example, readme files. Because sometimes 
+the links might be not accessible or out of date.
+
+
+## Solution
+TODO


### PR DESCRIPTION
# Course automation: Checking link validity in the course github text descriptions

## Members

Chen, Zidi: zidi@kth.se, https://github.com/Chen-Zidi
Chen, Sihan sihanc@kth.se, https://github.com/Spycsh


## Proposal

We want to check the validity of the deadlinks in the course github 
text descriptions, for example, readme files. Because sometimes 
the links might be not accessible or out of date.


## Solution
TODO