### PR TITLE
Demo: Publishing a Java package to Maven Central using Github Actions

### DIFF
--- a/contributions/demo/axp-fseifert/README.md
+++ b/contributions/demo/axp-fseifert/README.md
@@ -1,0 +1,19 @@
+# Video demo: Publishing a Java package to Maven Central using Github Actions
+
+## Members
+
+Axel Pettersson (axp@kth.se)
+GitHub: [Ackuq](https://github.com/Ackuq)
+
+Felix Seifert (fseifert@kth.se)
+Github: [felix-seifert](https://github.com/felix-seifert)
+
+## Proposal
+
+In this demo we will show how to create a simple Java package and deploying it to Maven Central for distribution using Github Actions.
+
+The action will:
+
+-   run when commits are pushed to main branch
+-   authenticate with Maven Central
+-   use encrypted Github Secrets to securely handle authentication

--- a/contributions/demo/axp-fseifert/README.md
+++ b/contributions/demo/axp-fseifert/README.md
@@ -15,5 +15,6 @@ In this demo we will show how to create a simple Java package and deploying it t
 The action will:
 
 -   run when commits are pushed to main branch
+-   update the version of the artifact to be published
 -   authenticate with Maven Central
 -   use encrypted Github Secrets to securely handle authentication


### PR DESCRIPTION
# Video demo: Publishing a Java package to Maven Central using Github Actions

## Members

Axel Pettersson (axp@kth.se)
GitHub: [Ackuq](https://github.com/Ackuq)

Felix Seifert (fseifert@kth.se)
Github: [felix-seifert](https://github.com/felix-seifert)

## Proposal

In this demo we will show how to create a simple Java package and deploying it to Maven Central for distribution using Github Actions.

The action will:

-   run when commits are pushed to main branch
-   authenticate with Maven Central
-   use encrypted Github Secrets to securely handle authentication
