### PR TITLE
Course automation: Notification for proposal-PR new comments

### DIFF
--- a/contributions/course-automation/isacarvid-aatif/README.md
+++ b/contributions/course-automation/isacarvid-aatif/README.md
@@ -10,12 +10,12 @@ Github: [isacarvid](https://github.com/isacarvid)
 
 ## Proposal
 
-We want to send a notification via email to all PR group members when a new comment on a proposal-PR has been made(new comment, approved, request changes). The problem arises as only the author of the PR would receive a notification normally, leaving the other members without knowledge of needed changes. Thereby providing an improvment to the course automation experience.
+We want to send a notification via email to all PR group members when a new comment on a proposal-PR has been made. The problem arises as only the author of the PR would receive a notification normally, leaving the other members without knowledge of needed changes. Thereby providing an improvment to the course automation experience.
 
 The requirements for the actions are:
 
 -   When a proposal-PR is commented it triggers github actions.
 -   Parse README.md to find all members.
--   Include PR-status and title of PR.
+-   Include title of PR.
 -   Include the new comment.
 -   Send email to all group members.

--- a/contributions/course-automation/isacarvid-aatif/README.md
+++ b/contributions/course-automation/isacarvid-aatif/README.md
@@ -1,0 +1,21 @@
+
+# Course automation: Send notification to all team members when a new PR-comment is made
+
+## Members
+Ayub Atif (aatif@kth.se)
+GitHub: [ayubatif](https://github.com/ayubatif)
+
+Isac Arvidsson (isacarv@kth.se)
+Github: [isacarvid](https://github.com/isacarvid)
+
+## Proposal
+
+We want to send a notification via email to all PR group members when a new comment on a proposal-PR has been made(new comment, approved, request changes). The problem arises as only the author of the PR would receive a notification normally, leaving the other members without knowledge of needed changes. Thereby providing an improvment to the course automation experience.
+
+The requirements for the actions are:
+
+-   When a proposal-PR is commented it triggers github actions.
+-   Parse README.md to find all members.
+-   Include PR-status and title of PR.
+-   Include the new comment.
+-   Send email to all group members.

--- a/contributions/course-automation/isacarvid-aatif/README.md
+++ b/contributions/course-automation/isacarvid-aatif/README.md
@@ -1,5 +1,5 @@
 
-# Course automation: Send notification to all team members when a new PR-comment is made
+# Course automation: Email notification for proposal-PR new comments
 
 ## Members
 Ayub Atif (aatif@kth.se)

--- a/contributions/course-automation/isacarvid-aatif/README.md
+++ b/contributions/course-automation/isacarvid-aatif/README.md
@@ -19,3 +19,5 @@ The requirements for the actions are:
 -   Include title of PR.
 -   Include the new comment.
 -   Send email to all group members.
+
+Note: The student can set on/off the notification (it will be off by default). This way, students who don't want to be notified are not going to receive email alerts.


### PR DESCRIPTION
# Course automation: Email notification for proposal-PR new comments

## Members
Ayub Atif (aatif@kth.se)
GitHub: [ayubatif](https://github.com/ayubatif)

Isac Arvidsson (isacarv@kth.se)
Github: [isacarvid](https://github.com/isacarvid)

## Proposal

We want to send a notification via email to all PR group members when a new comment on a proposal-PR has been made(new comment, approved, request changes). The problem arises as only the author of the PR would receive a notification normally, leaving the other members without knowledge of needed changes. Thereby providing an improvement to the course automation experience.

The requirements for the actions are:

-   When a proposal-PR is commented it triggers Github actions.
-   Parse README.md to find all members.
-   Include PR-status and title of PR.
-   Include the new comment.
-   Send email to all group members.