### PR TITLE
Presentation Proposal: DevSecOps takeaways from Hacking into Google's Network for $133,337

### DIFF
--- a/contributions/presentation/week5/aatif/README.md
+++ b/contributions/presentation/week5/aatif/README.md
@@ -1,0 +1,24 @@
+# Presentation Proposal: DevSecOps takeaways from Hacking into Google's Network for $133,337
+
+## Members
+Ayub Atif (aatif@kth.se)
+GitHub: [ayubatif](https://github.com/ayubatif)
+
+## Topic
+I want to use the report for a potential Remote Code Execution attack in Google Cloud Deployment Manager in May 2020 to give an overview of Google Cloud Deployment, 
+the security vulnerabilities observed, and the approach to finding such a bug. 
+The source is [Hacking into Google's Network for $133,337](https://www.ezequiel.tech/2020/05/rce-in-cloud-dm.html) by Ezequiel Pereira, which I followed up on from a comment
+by @monperrus on the Devops and Security issue.
+ 
+See outline for more detail.
+
+## Outline
+* What is Google Cloud Deployment Manager?
+* Short reminder of the DevSecOps concept.
+* What sort of approach is taken to find the vulnerabilties? (multiple options via audience interaction)
+* Where were the actual vulnerabilities?
+* Relating the vulnerabilities to other DevOps platforms you may work on.
+* Challenges and compromises in your DevSecOps solutions.
+* Takeaway introduction to bug bounty programs.
+
+The contents may be altered to fit the strict presentation timeframe, but the core content should remain.


### PR DESCRIPTION
## Members
Ayub Atif (aatif@kth.se)
GitHub: [ayubatif](https://github.com/ayubatif)

## Topic
I want to use the report for a potential Remote Code Execution attack in Google Cloud Deployment Manager in May 2020 to give an overview of Google Cloud Deployment, the security vulnerabilities observed, and the approach to finding such a bug. I follow this up with key takeaways relevant to the DevSecOps concept. The source is [Hacking into Google's Network for $133,337](https://www.ezequiel.tech/2020/05/rce-in-cloud-dm.html) by Ezequiel Pereira, which I followed up on from a comment by @monperrus on the Devops and Security issue #18.
 
See outline for more detail.

## Outline
* What is Google Cloud Deployment Manager?
* Short reminder of the DevSecOps concept.
* What sort of approach is taken to find the vulnerabilties? (multiple options via audience interaction)
* Where were the actual vulnerabilities?
* Relating the vulnerabilities to other DevOps platforms you may work on.
* Challenges and compromises in your DevSecOps solutions.
* Takeaway introduction to bug bounty programs.

The contents may be altered to fit the strict presentation timeframe, but the core content should remain.