### PR TITLE
Final Submission - Course Automation: Checking Open-Source Requirements

### DIFF
--- a/.github/workflows/open-source-requirement.yml
+++ b/.github/workflows/open-source-requirement.yml
@@ -1,0 +1,52 @@
+name: Open Source Activity Check
+on:
+  pull_request:
+    types:
+      - labeled
+    branches: [ 2021 ]
+
+jobs:
+  check-repo-activity-for-pr:
+    if: github.event.label.name == 'contribution_to_opensource'
+    runs-on: ubuntu-latest
+    name: PR activity check
+    steps:
+      - name: Run action
+        id: index
+        uses: sfkwww/milkyway@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          text: ${{ github.event.pull_request.body }}
+          min_stars: 10
+          min_watchers: 10
+          min_contributors: 10
+          min_forks: 1
+          min_commits: 100
+          min_commits_last_year: 10
+          min_open_issues: 10
+      - name: Comment the results
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `
+              [ ${{steps.index.outputs.repo}} ]
+              -----------------------
+              | Stat  |  Number |  Pass |
+              |---|---|---|
+              |Stars ⭐              | ${{fromJSON(steps.index.outputs.stars).count}}             | ${{ fromJSON('["❌", "✔️"]')[fromJSON(steps.index.outputs.stars).pass] }}   |
+              |Commits 📦            | ${{fromJSON(steps.index.outputs.commits).count}}           | ${{ fromJSON('["❌", "✔️"]')[fromJSON(steps.index.outputs.commits).pass] }} |
+              |Commits Last Year ⏱️  | ${{fromJSON(steps.index.outputs.commits_last_year).count}} | ${{ fromJSON('["❌", "✔️"]')[fromJSON(steps.index.outputs.commits_last_year).pass] }} |
+              |Watchers 👀           | ${{fromJSON(steps.index.outputs.watchers).count}}          | ${{ fromJSON('["❌", "✔️"]')[fromJSON(steps.index.outputs.watchers).pass] }} |
+              |Contributors 🧑🏻‍🤝‍🧑🏻       | ${{fromJSON(steps.index.outputs.contributors).count}}      | ${{ fromJSON('["❌", "✔️"]')[fromJSON(steps.index.outputs.contributors).pass] }} |
+              |Forks 🍴               | ${{fromJSON(steps.index.outputs.forks).count}}             | ${{ fromJSON('["❌", "✔️"]')[fromJSON(steps.index.outputs.forks).pass] }} |
+              |Open Issues 🟢        | ${{fromJSON(steps.index.outputs.open_issues).count}}       | ${{ fromJSON('["❌", "✔️"]')[fromJSON(steps.index.outputs.open_issues).pass] }} |
+              `
+            })
+            if (!${{steps.index.outputs.final_pass}}) {
+              core.setFailed('The repository did not meet the minimum requirements')
+            }

--- a/contributions/course-automation/oskstr-swill/README.md
+++ b/contributions/course-automation/oskstr-swill/README.md
@@ -61,3 +61,13 @@ An example would be:
 >  |Contributors 🧑🏻‍🤝‍🧑🏻       | 4135      | ✔️ |
 >  |Forks 🍴               | 7696             | ✔️ |
 >  |Open Issues 🟢        | 7056       | ✔️ |
+
+### Update according to change in grading criteria
+In a proposed update [#1209](https://github.com/KTH/devops-course/pull/1209) to the grading criteria for this task there are two additional requirements.
+
+1. Implemented in stand-alone repository (already done, no issue here)
+2. Demonstrate that automation technique actually works, for example in fork of [KTH/devops-course](https://github.com/KTH/devops-course) (we have tested but haven't provided a link)
+
+Here is a link to the Pull Request where we did our testing: [sfkwww/milkyway#2](https://github.com/sfkwww/milkyway/pull/2).
+
+Here is a link to the actions invoked during said testing: [sfkwww/milkyway/actions](https://github.com/sfkwww/milkyway/actions).

--- a/contributions/course-automation/oskstr-swill/README.md
+++ b/contributions/course-automation/oskstr-swill/README.md
@@ -13,6 +13,51 @@ The action should check that repo has:
 - More than 100 commits
 - An active community
   - open to interpretation
-  - provide stats on what has happend the last year (comments, PRs, commits)
+  - provide stats on what has happened the last year (comments, PRs, commits)
 
 We believe that checking that a project is related to DevOps may be too difficult for the purposes of this project.
+
+## Final Submission
+We have created a GitHub action at: https://github.com/sfkwww/milkyway
+
+The action can be used to find a link to an open-source GitHub repository in a body of text, like a pull request, and 
+get the following stats:
+ - stars
+ - watchers
+ - contributors
+ - forks
+ - commits
+ - commits last year
+ - open issues
+ 
+ The action can test that those stats satisfy some minimum requirement, e.g. 10 stars and 100 commits.
+ 
+ With this pull request we have added a file at `.github/workflows/open-source-requirement.yml` that 
+ would run this action whenever a pull request to `2021` gets the label `contribution_to_opensource`.
+ 
+ The minimum requirements currently in place are:
+ - stars: 10
+ - watchers: 10
+ - contributors: 10
+ - forks: 1
+ - commits: 100
+ - commits last year: 10
+ - open issues: 10
+ 
+ If needed they can be changed or removed. The default requirement is 0. 
+ 
+ The current workflow also uses `github-script` to comment a table of stats on the pull request.
+
+An example would be:
+
+>  [ rust-lang/rust ]
+>  -----------------------
+>  | Stat  |  Number |  Pass | 
+>  |---|---|---|
+>  |Stars ⭐              | 53440             | ✔️   |
+>  |Commits 📦            | 141152           | ✔️ |
+>  |Commits Last Year ⏱️  | 14472 | ✔️ |
+>  |Watchers 👀           | 1489          | ✔️ |
+>  |Contributors 🧑🏻‍🤝‍🧑🏻       | 4135      | ✔️ |
+>  |Forks 🍴               | 7696             | ✔️ |
+>  |Open Issues 🟢        | 7056       | ✔️ |


### PR DESCRIPTION
# Course Automation: Checking Open-Source Requirements

## Members
- [Oskar Strömberg](https://github.com/oskstr) (oskstr@kth.se)
- [Sebastian Williams](https://github.com/sfkwww) (swill@kth.se)

## Proposal

We would like to create a GitHub action that would automatically check the requirements for an open-souce contribution.

The action should check that repo has:
- More than 10 stars
- More than 100 commits
- An active community
  - open to interpretation
  - provide stats on what has happened the last year (comments, PRs, commits)

We believe that checking that a project is related to DevOps may be too difficult for the purposes of this project.

## Final Submission
We have created a GitHub action at: https://github.com/sfkwww/milkyway

The action can be used to find a link to an open-source GitHub repository in a body of text, like a pull request, and 
get the following stats:
 - stars
 - watchers
 - contributors
 - forks
 - commits
 - commits last year
 - open issues
 
 The action can test that those stats satisfy some minimum requirement, e.g. 10 stars and 100 commits.
 
 With this pull request we have added a file at `.github/workflows/open-source-requirement.yml` that 
 would run this action whenever a pull request to `2021` gets the label `contribution_to_opensource`.
 
 The minimum requirements currently in place are:
 - stars: 10
 - watchers: 10
 - contributors: 10
 - forks: 1
 - commits: 100
 - commits last year: 10
 - open issues: 10
 
 If needed they can be changed or removed. The default requirement is 0. 
 
 The current workflow also uses `github-script` to comment a table of stats on the pull request.

An example would be:

>  [ rust-lang/rust ]
>  -----------------------
>  | Stat  |  Number |  Pass | 
>  |---|---|---|
>  |Stars ⭐              | 53440             | ✔️   |
>  |Commits 📦            | 141152           | ✔️ |
>  |Commits Last Year ⏱️  | 14472 | ✔️ |
>  |Watchers 👀           | 1489          | ✔️ |
>  |Contributors 🧑🏻‍🤝‍🧑🏻       | 4135      | ✔️ |
>  |Forks 🍴               | 7696             | ✔️ |
>  |Open Issues 🟢        | 7056       | ✔️ |

### Update according to change in grading criteria
In a proposed update [#1209](https://github.com/KTH/devops-course/pull/1209) to the grading criteria for this task there are two additional requirements.

1. Implemented in stand-alone repository (already done, no issue here)
2. Demonstrate that automation technique actually works, for example in fork of [KTH/devops-course](https://github.com/KTH/devops-course) (we have tested but haven't provided a link)

Here is a link to the Pull Request where we did our testing: [sfkwww/milkyway#2](https://github.com/sfkwww/milkyway/pull/2).

Here is a link to the actions invoked during said testing: [sfkwww/milkyway/actions](https://github.com/sfkwww/milkyway/actions).

