### PR TITLE
Executable tutorial proposal: AWS with Clojure 

### DIFF
--- a/contributions/executable-tutorial/felixfon-bouaddi/README.md
+++ b/contributions/executable-tutorial/felixfon-bouaddi/README.md
@@ -1,0 +1,11 @@
+# Using the Clojure library AWS-api to access AWS services  
+
+## Members
+
+Félix Fonteneau, felixfon@kth.se (github username: [FelixFonteneau](https://github.com/FelixFonteneau))
+
+Hilaire Bouaddi, bouaddi@kth.se (github username: [Hilaire-Bouaddi](https://github.com/Hilaire-Bouaddi))
+
+## Proposal
+
+The functional programming language Clojure allows easy execution of scripts with its built-in REPL. The library AWS-api makes it easy to use the AWS tools from Clojure. AWS APIs operations are described in data that can be used recursively, this makes AWS very well suited for a fundamentally functional programming language such as Clojure. Combinated with Clojure, this library is a powerful alternative to AWS CLI and bash scripts to access the tools of AWS. In this executable tutorial, we would explain how to use the library to access AWS Services. 


### PR DESCRIPTION
# Using the Clojure library AWS-api to access AWS services  

## Members

Félix Fonteneau, felixfon@kth.se (github username: [FelixFonteneau](https://github.com/FelixFonteneau))
Hilaire Bouaddi, bouaddi@kth.se (github username: [Hilaire-Bouaddi](https://github.com/Hilaire-Bouaddi))

## Proposal

The functional programming language Clojure allows easy execution of scripts with its built-in REPL. The library AWS-api makes it easy to use the AWS tools from Clojure. AWS APIs operations are described in data that can be used recursively, this makes AWS very well suited for a fundamentally functional programming language such as Clojure. Combinated with Clojure, this library is a powerful alternative to AWS CLI and bash scripts to access the tools of AWS. In this executable tutorial, we would explain how to use the library to access AWS Services. 
