### PR TITLE
Demo: Automatically generate Python unittest results in HTML reports with Jenkins

### DIFF
--- a/contributions/demo/sihanc-yuehao/README.md
+++ b/contributions/demo/sihanc-yuehao/README.md
@@ -1,0 +1,15 @@
+# Demo: Automatically generate Python unittest results in HTML reports with Jenkins 
+
+## Member
+
+Name: Sihan Chen,  Yuehao Sui
+
+Mail: sihanc@kth.se, yuehao@kth.se
+
+Github: Spycsh, amaothree
+
+## Proposal
+The demo will show how to automatically generate and visualize Python unittest results in HTML reports with Jenkins. The component to elegantly show the testing results in HTML reports is [HTMLTestRunner](https://github.com/SeldomQA/HTMLTestRunner). The video will show how it can be intergrated into Jenkins in a CI testing flow.
+
+This is quite relevant to DevOps because jenkins is widely used for CI but there are no native support to generate HTML testing report for Python unittest. We hope this video demo will clearly show the whole flow.
+


### PR DESCRIPTION
# Demo: Automatically generate Python unittest results in HTML reports with Jenkins 

## Member

Name: Sihan Chen,  Yuehao Sui

Mail: sihanc@kth.se, yuehao@kth.se

Github: Spycsh, amaothree

## Proposal
The demo will show how to automatically generate and visualize Python unittest results in HTML reports with Jenkins. The component to elegantly show the testing results in HTML reports is [HTMLTestRunner](https://github.com/SeldomQA/HTMLTestRunner). The video will show how it can be intergrated into Jenkins in a CI testing flow.

This is quite relevant to DevOps because jenkins is widely used for CI but there are no native support to generate HTML testing report for Python unittest. We hope this video demo will clearly show the whole flow.