### PR TITLE
feat: GHA to check essay word count

### DIFF
--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            if [ $added_modified_file == *"contributions/essay/"* ] && [ $added_modified_file == *"pdf" ] ; then
+            if [ "$added_modified_file" == *"contributions/essay/"* ] && [ "$added_modified_file" == *"pdf" ] ; then
               words = $(pdftotext ${added_modified_files[@]} | wc -w)
               echo "Word Count: ${words}"
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,9 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            words = $(sudo pdftotext ${added_modified_file} | wc -w)
+            sudo pdftotext contributions/essay/khaes/Turing_Chinese_Room.pdf | wc -w
+            echo "DONE"
+            #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"
             if [ "${added_modified_file}" == *"contributions/essay/"* ] && [ "${added_modified_file}" == *"pdf" ] ; then
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Install xpdf
         run: sudo apt-get install -y xpdf
       - id: files
+        if: github.context.payload && github.context.payload.pull_request && github.context.payload.pull_request.title == 'HI'
         uses: jitterbit/get-changed-files@v1
       - name: Check the submitted essays
         run: >

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -17,7 +17,7 @@ jobs:
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"
-              if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then
+              if [ $words -lt 600 ] || [ $words -gt 700 ]; then
                 exit 1
               fi
             fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,12 +15,10 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo pdftotext $added_modified_file - | wc -w
-            echo "DONE"
-            #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"
-            if [ "${added_modified_file}" == *"contributions/essay/"* ] && [ "${added_modified_file}" == *"pdf" ] ; then
-              if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then
+            if [ "$added_modified_file" == *"contributions/essay/"* ] && [ "$added_modified_file" == *"pdf" ] ; then
+              words = sudo pdftotext $added_modified_file - | wc -w)
+              if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then
                 exit 1
               fi
             fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,10 +14,9 @@ jobs:
       - name: Check the submitted essays
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
-            echo "Checking file: $added_modified_file"
-            echo "Word Count: ${words}"
             if [ "$added_modified_file" == *"contributions/essay/"* ] && [ "$added_modified_file" == *"pdf" ] ; then
-              words = sudo pdftotext $added_modified_file - | wc -w)
+              words = $(sudo pdftotext $added_modified_file - | wc -w)
+              echo "File $added_modified_file has $words words"
               if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then
                 exit 1
               fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -18,7 +18,7 @@ jobs:
           if [[ $added_files == *" "* ]]; then
             echo "The added file names should not contain whitespace"
             exit 1
-          fi
+          fi;
           added_files=${added_files//\"/ };
           added_files=${added_files/[/};
           added_files=${added_files/]/};

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install xpdf
         run: sudo apt-get install -y xpdf
-      - id: files
-        uses: jitterbit/get-changed-files@v1
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
       - name: Check the submitted essays
         run: >
-          for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
+          for added_modified_file in ${{ steps.file_changes.outputs.files_added  }}; do
             echo "Checking file: $added_modified_file"
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -11,15 +11,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xpdf
       - id: files
         uses: jitterbit/get-changed-files@v1
-        with:
-          format: csv
       - name: Check the submitted essays
         run: >
-          mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
-
-          for added_modified_file in "${added_modified_files[@]}"; do
+          for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             if [ ${added_modified_files[@]} == *"/contributions/essay/"* ] && [ ${added_modified_files[@]} == *"pdf" ] ; then
               words = $(pdftotext ${added_modified_files[@]} | wc -w)
+              echo "Word Count: ${words}"
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then
                 exit 1
               fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -54,6 +54,7 @@ jobs:
               if [ ${added_modified_files[@]} == *"/contributions/essay/"* ]; then
                 words = $(pdftotext ${added_modified_files[@]} | wc -w)
                 if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then
+                  exit 1
                 fi
               fi
             done

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -18,7 +18,7 @@ jobs:
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"
-              if [ $words -lt 1800 ] || [ $words -gt 2000 ]; then
+              if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then
                 exit 1
               fi
             fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt-get install -y xpdf
 
       # Runs a single command using the runners shell
-      - name: Update the statistic issue
+      - name: Check the submitted essays
         - id: files
           uses: jitterbit/get-changed-files@v1
           with:

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,10 +14,10 @@ jobs:
         uses: trilom/file-changes-action@v1.2.3
       - name: Check the submitted essays
         run: >
-          added_files='${{ steps.file_changes.outputs.files_added  }}'
-          added_files=${added_files/\"/ }
-          added_files=${added_files/[/ }
-          added_files=${added_files/]/ }
+          added_files='${{ steps.file_changes.outputs.files_added  }}';
+          added_files=${added_files/\"/ };
+          added_files=${added_files/[/ };
+          added_files=${added_files/]/ };
           for added_modified_file in ${added_files[@]}; do
             echo "Checking file: $added_modified_file"
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -23,7 +23,7 @@ jobs:
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"
-              if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then
+              if [ $words -lt 500 ] || [ $words -gt 700 ]; then
                 exit 1
               fi
             fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,7 +14,8 @@ jobs:
         uses: trilom/file-changes-action@v1.2.3
       - name: Check the submitted essays
         run: >
-          for added_modified_file in ${{ steps.file_changes.outputs.files_added  }}; do
+          added_files = ${{ steps.file_changes.outputs.files_added  }}
+          for added_modified_file in ${added_files[@]}; do
             echo "Checking file: $added_modified_file"
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo ls -lh $added_modified_file | wc -w
+            sudo pdftotext $added_modified_file - | wc -w
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo ll contributions/essay/khaes/Turing_Chinese_Room.pdf
+            sudo ll
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -27,7 +27,7 @@ jobs:
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"
-              if [ $words -lt 500 ] || [ $words -gt 700 ]; then
+              if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then
                 exit 1
               fi
             fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -1,8 +1,6 @@
 name: Checking the Word Count of Submitted Essay
 'on':
-  pull_request:
-    branches:
-      - '2021'
+  pull_request
   workflow_dispatch: null
 jobs:
   check-essay:

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo ls contributions/essay/khaes/Turing_Chinese_Room.pdf
+            sudo pdftotext contributions/essay/khaes/Turing_Chinese_Room.pdf
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check the submitted essays
         run: >
           added_files='${{ steps.file_changes.outputs.files_added  }}'
-          added_files=${added_files/"/ }
+          added_files=${added_files/\"/ }
           added_files=${added_files/[/ }
           added_files=${added_files/]/ }
           for added_modified_file in ${added_files[@]}; do

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -5,7 +5,7 @@ name: Checking the Word Count of Submitted Essay
 jobs:
   check-essay:
     runs-on: ubuntu-18.04
-    if: ${{ contains(github.head_ref, 'essay') }}
+    if: ${{ contains(github.head_ref, 'essay-added') }}
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo pdftotext $added_modified_file
+            sudo ls -lh $added_modified_file | wc -w
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo pdftotext contributions/essay/khaes/Turing_Chinese_Room.pdf
+            sudo ll contributions/essay/khaes/Turing_Chinese_Room.pdf
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,7 +14,10 @@ jobs:
         uses: trilom/file-changes-action@v1.2.3
       - name: Check the submitted essays
         run: >
-          added_files=${{ steps.file_changes.outputs.files_added  }}
+          added_files="${{ steps.file_changes.outputs.files_added  }}"
+          added_files=${added_files/"/ }
+          added_files=${added_files/[/ }
+          added_files=${added_files/]/ }
           for added_modified_file in ${added_files[@]}; do
             echo "Checking file: $added_modified_file"
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -5,7 +5,7 @@ name: Checking the Word Count of Submitted Essay
 jobs:
   check-essay:
     runs-on: ubuntu-18.04
-    if: ${{ contains(github.head_ref, 'essay-word-count-check') }}
+    if: ${{ contains(github.head_ref, 'essay-submission') }}
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Check the submitted essays
         run: >
           added_files='${{ steps.file_changes.outputs.files_added  }}';
-          added_files=${added_files/\"/ };
-          added_files=${added_files/[/ };
-          added_files=${added_files/]/ };
+          added_files=${added_files//\"/ };
+          added_files=${added_files/[/};
+          added_files=${added_files/]/};
           for added_modified_file in ${added_files[@]}; do
             echo "Checking file: $added_modified_file"
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            words = $(pdftotext ${added_modified_file} | wc -w)
+            words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"
             if [ "${added_modified_file}" == *"contributions/essay/"* ] && [ "${added_modified_file}" == *"pdf" ] ; then
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            if [ "$added_modified_file" == *"contributions/essay/"* ] && [ "$added_modified_file" == *"pdf" ] ; then
+            if [ "${added_modified_file}" == *"contributions/essay/"* ] && [ "${added_modified_file}" == *"pdf" ] ; then
               words = $(pdftotext ${added_modified_files[@]} | wc -w)
               echo "Word Count: ${words}"
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,7 +14,7 @@ jobs:
         uses: trilom/file-changes-action@v1.2.3
       - name: Check the submitted essays
         run: >
-          added_files="${{ steps.file_changes.outputs.files_added  }}"
+          added_files='${{ steps.file_changes.outputs.files_added  }}'
           added_files=${added_files/"/ }
           added_files=${added_files/[/ }
           added_files=${added_files/]/ }

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install xpdf
         run: sudo apt-get install -y xpdf
       - id: files
-        if: github.context.payload && github.context.payload.pull_request
+        if: ${{contains(github.context.payload.pull_request, 'essay')}}
         uses: jitterbit/get-changed-files@v1
       - name: Check the submitted essays
         run: >

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -9,15 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set timezone
-        run: sudo timedatectl set-timezone Europe/Stockholm
       - name: Install xmllint
         run: sudo apt-get install -y xpdf
-      - name: Check the submitted essays
-        id: files
+      - id: files
         uses: jitterbit/get-changed-files@v1
         with:
           format: csv
+      - name: Check the submitted essays
         run: >
           mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
 

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -1,0 +1,59 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Checking the Word Count of Submitted Essay
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the 2021 branch
+  pull_request:
+    branches:
+    - "2021"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  check-essay:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Setup Python
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f ./tools/requirements.txt ]; then pip install -r ./tools/requirements.txt; fi
+
+      # Set timezone to Europe/Stockholm
+      - name: Set timezone
+        run: sudo timedatectl set-timezone Europe/Stockholm
+        
+      - name: Install xmllint
+        run: sudo apt-get install -y xpdf
+
+      # Runs a single command using the runners shell
+      - name: Update the statistic issue
+        - id: files
+          uses: jitterbit/get-changed-files@v1
+          with:
+            format: 'csv'
+        - run: |
+            mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
+            for added_modified_file in "${added_modified_files[@]}"; do
+              if [ ${added_modified_files[@]} == *"/contributions/essay/"* ]; then
+                words = $(pdftotext ${added_modified_files[@]} | wc -w)
+                if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then
+                fi
+              fi
+            done

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -5,7 +5,7 @@ name: Checking the Word Count of Submitted Essay
 jobs:
   check-essay:
     runs-on: ubuntu-18.04
-    if: ${{ contains(github.head_ref, 'essay-added') }}
+    if: ${{ contains(github.head_ref, 'essay-word-count-check') }}
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -4,7 +4,7 @@ name: Checking the Word Count of Submitted Essay
   workflow_dispatch: []
 jobs:
   check-essay:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo ll
+            sudo ls -lh $added_modified_file
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -5,7 +5,7 @@ name: Checking the Word Count of Submitted Essay
 jobs:
   check-essay:
     runs-on: ubuntu-18.04
-    if: contains('essay', 'essay')
+    if: ${{ contains(github.head_ref, 'essay') }}
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -18,7 +18,7 @@ jobs:
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"
-              if [ $words -lt 600 ] || [ $words -gt 700 ]; then
+              if [ $words -lt 1800 ] || [ $words -gt 2000 ]; then
                 exit 1
               fi
             fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Check the submitted essays
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
+            echo "Checking file: $added_modified_file"
             if [ $added_modified_file == *"/contributions/essay/"* ] && [ $added_modified_file == *"pdf" ] ; then
               words = $(pdftotext ${added_modified_files[@]} | wc -w)
               echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check the submitted essays
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
-            if [ "$added_modified_file" == *"contributions/essay/"* ] && [ "$added_modified_file" == *"pdf" ] ; then
+            if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words = $(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"
               if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            if [ $added_modified_file == *"/contributions/essay/"* ] && [ $added_modified_file == *"pdf" ] ; then
+            if [ $added_modified_file == *"contributions/essay/"* ] && [ $added_modified_file == *"pdf" ] ; then
               words = $(pdftotext ${added_modified_files[@]} | wc -w)
               echo "Word Count: ${words}"
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install xpdf
         run: sudo apt-get install -y xpdf
       - id: files
-        if: github.context.payload && github.context.payload.pull_request && github.context.payload.pull_request.title == 'HI'
+        if: github.context.payload && github.context.payload.pull_request
         uses: jitterbit/get-changed-files@v1
       - name: Check the submitted essays
         run: >

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -8,16 +8,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf
-        run: sudo apt-get update && sudo apt-get install -y xpdf
+        run: sudo apt-get install -y xpdf
       - id: files
         uses: jitterbit/get-changed-files@v1
       - name: Check the submitted essays
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
+            words = $(pdftotext ${added_modified_file} | wc -w)
+            echo "Word Count: ${words}"
             if [ "${added_modified_file}" == *"contributions/essay/"* ] && [ "${added_modified_file}" == *"pdf" ] ; then
-              words = $(pdftotext ${added_modified_files[@]} | wc -w)
-              echo "Word Count: ${words}"
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then
                 exit 1
               fi

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
-              words = $(sudo pdftotext $added_modified_file - | wc -w)
+              words=$(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"
               if [ $words -lt 1800 ] || [ $words -gt 2200 ]; then
                 exit 1

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check the submitted essays
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
-            if [ ${added_modified_files[@]} == *"/contributions/essay/"* ] && [ ${added_modified_files[@]} == *"pdf" ] ; then
+            if [ $added_modified_file == *"/contributions/essay/"* ] && [ $added_modified_file == *"pdf" ] ; then
               words = $(pdftotext ${added_modified_files[@]} | wc -w)
               echo "Word Count: ${words}"
               if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -1,6 +1,7 @@
 name: Checking the Word Count of Submitted Essay
 'on':
-  pull_request
+  pull_request:
+  workflow_dispatch: []
 jobs:
   check-essay:
     runs-on: ubuntu-latest

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo pdftotext contributions/essay/khaes/Turing_Chinese_Room.pdf | wc -w
+            sudo ls contributions/essay/khaes/Turing_Chinese_Room.pdf
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Check the submitted essays
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
+            echo "Checking file: $added_modified_file"
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then
               words=$(sudo pdftotext $added_modified_file - | wc -w)
               echo "File $added_modified_file has $words words"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install xmllint
-        run: sudo apt-get install -y xpdf
+      - name: Install xpdf
+        run: sudo apt-get update && sudo apt-get install -y xpdf
       - id: files
         uses: jitterbit/get-changed-files@v1
         with:

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -14,7 +14,7 @@ jobs:
         uses: trilom/file-changes-action@v1.2.3
       - name: Check the submitted essays
         run: >
-          added_files = ${{ steps.file_changes.outputs.files_added  }}
+          added_files=${{ steps.file_changes.outputs.files_added  }}
           for added_modified_file in ${added_files[@]}; do
             echo "Checking file: $added_modified_file"
             if [[ "$added_modified_file" == *"contributions/essay/"* ]] && [[ "$added_modified_file" == *"pdf" ]] ; then

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -1,60 +1,31 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Checking the Word Count of Submitted Essay
-
-# Controls when the action will run. 
-on:
-  # Triggers the workflow on push or pull request events but only for the 2021 branch
+'on':
   pull_request:
     branches:
-    - "2021"
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+      - '2021'
+  workflow_dispatch: null
 jobs:
-  # This workflow contains a single job called "build"
   check-essay:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
-      # Setup Python
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f ./tools/requirements.txt ]; then pip install -r ./tools/requirements.txt; fi
-
-      # Set timezone to Europe/Stockholm
       - name: Set timezone
         run: sudo timedatectl set-timezone Europe/Stockholm
-        
       - name: Install xmllint
         run: sudo apt-get install -y xpdf
-
-      # Runs a single command using the runners shell
       - name: Check the submitted essays
-        - id: files
-          uses: jitterbit/get-changed-files@v1
-          with:
-            format: 'csv'
-        - run: |
-            mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
-            for added_modified_file in "${added_modified_files[@]}"; do
-              if [ ${added_modified_files[@]} == *"/contributions/essay/"* ]; then
-                words = $(pdftotext ${added_modified_files[@]} | wc -w)
-                if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then
-                  exit 1
-                fi
+        id: files
+        uses: jitterbit/get-changed-files@v1
+        with:
+          format: csv
+        run: >
+          mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
+
+          for added_modified_file in "${added_modified_files[@]}"; do
+            if [ ${added_modified_files[@]} == *"/contributions/essay/"* ] && [ ${added_modified_files[@]} == *"pdf" ] ; then
+              words = $(pdftotext ${added_modified_files[@]} | wc -w)
+              if [ "$words" -lt 1800 ] || [ "$words" -gt 2200 ]; then
+                exit 1
               fi
-            done
+            fi
+          done

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,7 +15,7 @@ jobs:
         run: >
           for added_modified_file in ${{ steps.files.outputs.added_modified  }}; do
             echo "Checking file: $added_modified_file"
-            sudo ls -lh $added_modified_file
+            sudo pdftotext $added_modified_file
             echo "DONE"
             #words = $(sudo pdftotext ${added_modified_file} | wc -w)
             echo "Word Count: ${words}"

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -5,7 +5,7 @@ name: Checking the Word Count of Submitted Essay
 jobs:
   check-essay:
     runs-on: ubuntu-18.04
-    if: contains(github.ref, 'essay')
+    if: contains('essay', 'essay')
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -15,6 +15,10 @@ jobs:
       - name: Check the submitted essays
         run: >
           added_files='${{ steps.file_changes.outputs.files_added  }}';
+          if [[ $added_files == *" "* ]]; then
+            echo "The added file names should not contain whitespace"
+            exit 1
+          fi
           added_files=${added_files//\"/ };
           added_files=${added_files/[/};
           added_files=${added_files/]/};

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -1,7 +1,6 @@
 name: Checking the Word Count of Submitted Essay
 'on':
   pull_request
-  workflow_dispatch: null
 jobs:
   check-essay:
     runs-on: ubuntu-latest

--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -5,12 +5,12 @@ name: Checking the Word Count of Submitted Essay
 jobs:
   check-essay:
     runs-on: ubuntu-18.04
+    if: contains(github.ref, 'essay')
     steps:
       - uses: actions/checkout@v2
       - name: Install xpdf
         run: sudo apt-get install -y xpdf
       - id: files
-        if: ${{contains(github.context.payload.pull_request, 'essay')}}
         uses: jitterbit/get-changed-files@v1
       - name: Check the submitted essays
         run: >

--- a/contributions/essay/README.md
+++ b/contributions/essay/README.md
@@ -10,3 +10,5 @@ TA will review the PR. If it is accepted, you could begin your work on this topi
 ## Final Submission
 
 You should make another pull-request which contains your PDF file of the essay.
+
+The PDF filename should end with ".pdf" and should not contain whitespace. Also, the branch from which you create the pull request should contain `essay-submission` in its name. These are required for our Github Action to check if your essay's word count is in the limits.

--- a/contributions/essay/README.md
+++ b/contributions/essay/README.md
@@ -9,4 +9,4 @@ TA will review the PR. If it is accepted, you could begin your work on this topi
 
 ## Final Submission
 
-You should make another pull-request which contains your PDF file of the essay.
+You should make another pull-request which contains your PDF file of the essay. The PDF filename should end with ".pdf" and should not include white space or special characters.

--- a/contributions/essay/README.md
+++ b/contributions/essay/README.md
@@ -9,4 +9,4 @@ TA will review the PR. If it is accepted, you could begin your work on this topi
 
 ## Final Submission
 
-You should make another pull-request which contains your PDF file of the essay. The PDF filename should end with ".pdf" and should not include white space or special characters.
+You should make another pull-request which contains your PDF file of the essay.


### PR DESCRIPTION
This PR checks the submitted essay's word count to lie in [1800, 2200] interval.

For each PR, all added or modified files are checked and if they are in the "contribution/essay" folder and have a ".pdf" extension, this GHA runs "pdftotext $file - | wc -w" on them to count the words.

To make sure it is an essay submission, the head branch name should contain `essay-submission`, also the added filenames should not include whitespace. This PR also updates the README according to these rules.