### PR TITLE
Moving from Integrity to Abstruse

### DIFF
--- a/contributions/executable-tutorial/renstr-alekru/README.md
+++ b/contributions/executable-tutorial/renstr-alekru/README.md
@@ -1,0 +1,19 @@
+# Executable-tutorial: Setting up a Linode server running Abstruse for Continuous Integration testing with automated performance alerts
+
+[Abstruse](https://github.com/bleenco/abstruse)  
+[Linode](https://www.linode.com/)
+
+## Members
+
+Alexander Kruger [@alekru](https://github.com/thestar19)
+Anders Renström [@renstr](https://github.com/Renstrom)
+
+## Proposal
+
+Offering similar services as AWS as early as 2003, Linode has offered a worldclass cloud infrastructure for nearly two decades.
+Today, it is one of largest independent open cloud providers and is therefore a fitting mate for opensource continuous integration tool such as Integrity.
+
+The aim of our tutorial is to enable developers to quickly get an Abstruse environment running on Linodes cloud, so that they can hit the ground running for their next project without fear for any of the major providers dislike.
+This will also include instructions on setting up a automated performance alert, as to avoid wasting compute cycles.
+
+The switch from Integrity to Abstruse was made due to major compatability problems within Integrity's dependencies, as well as Integrity being outdated.


### PR DESCRIPTION
Due to Integrity having significant problems with compatibility due to some aspects of it not being updated for over 10 (!) years, it makes much much more sense to focus on a modern CI tool such as Abstruse. 