### PR TITLE
Remove Periods in Word Count

### DIFF
--- a/.github/workflows/essay-word-count.yml
+++ b/.github/workflows/essay-word-count.yml
@@ -23,7 +23,7 @@ jobs:
             added_file=${item//;/ };
             echo "Checking file: $added_file"
             if [[ "$added_file" == *"contributions/essay/"* ]] && [[ "$added_file" == *"pdf" ]] ; then
-              words=$(sudo pdftotext "${added_file}" - | wc -w)
+              words=$(sudo pdftotext "${added_file}" - | tr -d '.' | wc -w)
               echo "File $added_file has $words words"
               if [ $words -lt 1900 ] || [ $words -gt 2100 ]; then
                 exit 1


### PR DESCRIPTION
* Enhance command for counting word with removal of periods before counting
* LaTeX files often use period signs to seperate names of sections/subsections from their page number in the content table. To avoid these periods being counted as words, periods should be removed before counting the word number.