### PR TITLE
Proposal: Contribution to open-source

### DIFF
--- a/contributions/open-source/ppjha-faivre/README.md
+++ b/contributions/open-source/ppjha-faivre/README.md
@@ -1,0 +1,25 @@
+# Assignment Proposal
+
+## Title
+
+Open source contribution on a [Lint Action](https://github.com/marketplace/actions/lint-action), an github action that shows linting errors and allows auto-fixing issues.
+
+## Names and KTH ID
+  - Philip Hamelink (ppjhad@kth.se)
+  - Bastien Faivre (faivre@kth.se)
+## Deadline
+
+Task 2: April 19, 17h
+
+## Category
+
+Contribution to open-source
+
+## Description
+
+We want to add a feature mentioned in this [issue](https://github.com/wearerequired/lint-action/issues/426). Currently, this action allows to set 
+auto-fixing linting errors for all linters. There has been a requested feature to only allow auto-fixing for certain linters, which we want to
+add ourselves. The repo has 329 :star: and 509 commits. The community is quite active. The issue was requested 7 days ago, and the author responded and 
+labeled the issue with "help_wanted" 2 days ago. 
+
+We believe this satisfies the requirements for the open-source contribution assignment as linting code on commits is an invaluabe feature in DevOps.


### PR DESCRIPTION
# Assignment Proposal

## Title

Open source contribution on a [Lint Action](https://github.com/marketplace/actions/lint-action), an github action that shows linting errors and allows auto-fixing issues.

## Names and KTH ID
  - Philip Hamelink (ppjhad@kth.se)
  - Bastien Faivre (faivre@kth.se)
## Deadline

Task 2: April 19, 17h

## Category

Contribution to open-source

## Description

We want to add a feature mentioned in this [issue](https://github.com/wearerequired/lint-action/issues/426). Currently, this action allows to set 
auto-fixing linting errors for all linters. There has been a requested feature to only allow auto-fixing for certain linters, which we want to
add ourselves. The repo has 329 :star: and 509 commits. The community is quite active. The issue was requested 7 days ago, and the author responded and 
labeled the issue with "help_wanted" 2 days ago. 

We believe this satisfies the requirements for the open-source contribution assignment as linting code on commits is an invaluabe feature in DevOps.