### PR TITLE
Proposal: Kataconda Ansible Playbook to automate the MERN stack setup

### DIFF
--- a/contributions/executable-tutorial/yilinc-ntli/README.md
+++ b/contributions/executable-tutorial/yilinc-ntli/README.md
@@ -2,7 +2,7 @@
 
 ## Title
 
-Ansible Playbook to deploy the MERN stack to AWS EC2
+Ansible Playbook to automate the MERN stack setup
 
 ## Names and KTH ID
 
@@ -20,6 +20,5 @@ Executable tutorial
 ## Description
 
 Infrastructure as Code (IaC) is the managing and provisioning of infrastructure through code instead of through manual processes. Ansible is an automation tool that helps people perform IaC. 
-
-We want to create a Kataconda to show how to use an Ansible Playbook to automate the deployment of MERN (a very common tech stack consisting of MongoDB, Express, React, Node) to AWS EC2 instances.
+We want to create a Kataconda to show how to use an Ansible Playbook to automate the setup of MERN (a very common tech stack consisting of MongoDB, Express, React, Node).
 

--- a/contributions/executable-tutorial/yilinc-ntli/README.md
+++ b/contributions/executable-tutorial/yilinc-ntli/README.md
@@ -21,4 +21,5 @@ Executable tutorial
 
 MERN is a very common tech stack consisting of MongoDB, Express, React, Node. 
 We want to create a Kataconda, to show how to automate the deployment of this tech-stack to AWS EC2 instances using an Ansbile Playbook. 
+This way we create and configure the infrastrucutre with code.
 

--- a/contributions/executable-tutorial/yilinc-ntli/README.md
+++ b/contributions/executable-tutorial/yilinc-ntli/README.md
@@ -19,7 +19,7 @@ Executable tutorial
 
 ## Description
 
-MERN is a very common tech stack consisting of MongoDB, Express, React, Node. 
-We want to create a Kataconda, to show how to automate the deployment of this tech-stack to AWS EC2 instances using an Ansbile Playbook. 
-This way we create and configure the infrastrucutre with code.
+Infrastructure as Code (IaC) is the managing and provisioning of infrastructure through code instead of through manual processes. Ansible is an automation tool that helps people perform IaC. 
+
+We want to create a Kataconda to show how to use an Ansible Playbook to automate the deployment of MERN (a very common tech stack consisting of MongoDB, Express, React, Node) to AWS EC2 instances.
 

--- a/contributions/executable-tutorial/yilinc-ntli/README.md
+++ b/contributions/executable-tutorial/yilinc-ntli/README.md
@@ -1,0 +1,24 @@
+# Assignment Proposal
+
+## Title
+
+Ansible Playbook to deploy the MERN stack to AWS EC2
+
+## Names and KTH ID
+
+- Yilin Chang (yilinc@kth.se)
+- Nikolai Limbrunner (ntli@kth.se)
+
+## Deadline
+
+Task 2
+
+## Category
+
+Executable tutorial
+
+## Description
+
+MERN is a very common tech stack consisting of MongoDB, Express, React, Node. 
+We want to create a Kataconda, to show how to automate the deployment of this tech-stack to AWS EC2 instances using an Ansbile Playbook. 
+


### PR DESCRIPTION
# Assignment Proposal

## Title

Ansible Playbook to automate the MERN stack setup

## Names and KTH ID

- Yilin Chang (yilinc@kth.se)
- Nikolai Limbrunner (ntli@kth.se)

## Deadline

Task 2

## Category

Executable tutorial

## Description

Infrastructure as Code (IaC) is the managing and provisioning of infrastructure through code instead of through manual processes. Ansible is an automation tool that helps people perform IaC. 
We want to create a Kataconda to show how to use an Ansible Playbook to automate the setup of MERN (a very common tech stack consisting of MongoDB, Express, React, Node).
