### PR TITLE
Executable tutorial proposal: Cron jobs

### DIFF
--- a/contributions/executable-tutorial/ersode/README.md
+++ b/contributions/executable-tutorial/ersode/README.md
@@ -1,0 +1,26 @@
+# Assignment Proposal
+
+## Title
+
+Using cron to schedule tasks
+
+## Names and KTH ID
+
+- Eric Söderberg (ersode)
+
+## Deadline
+
+Task 2
+
+## Category
+
+Executable Tutorial
+
+## Description
+
+
+This tutorial, implemented in Katacoda, aims to familiarize the user with using cron, or cron jobs, to schedule tasks. 
+
+Cron jobs are invaluable tools that sees heavy use in devops, whenever jobs are required to be run on a set schedule. Previous [students have expressed](https://github.com/KTH/devops-course/pull/1271#issuecomment-823569227) have expressed confusion upon encountering this concept used in other tutorials.
+
+The tutorial will, apart from teaching basic commands such as crontab, present theoretical scenarios in which this method of scheduling is useful, and depending on time, _might_ also showcase why knowledge about cron job syntax is useful for other similar tools (such as google's Cloud Scheduler).


### PR DESCRIPTION
# Assignment Proposal

## Title

Using cron to schedule tasks

## Names and KTH ID

- Eric Söderberg (ersode)

## Deadline

Task 2

## Category

Executable Tutorial

## Description


This tutorial, implemented in Katacoda, aims to familiarize the user with using cron, or cron jobs, to schedule tasks. 

Cron jobs are invaluable tools that sees heavy use in devops, whenever jobs are required to be run on a set schedule. Previous [students have expressed](https://github.com/KTH/devops-course/pull/1271#issuecomment-823569227) have expressed confusion upon encountering this concept used in other tutorials.

The tutorial will, apart from teaching basic commands such as crontab, present theoretical scenarios in which this method of scheduling is useful, and depending on time, _might_ also showcase why knowledge about cron job syntax is useful for other similar tools (such as google's Cloud Scheduler).
