### PR TITLE
Demo proposal: Sending Microsoft Azure security advisories to Slack

### DIFF
--- a/contributions/demo/week7-dependency-DevSecOps/ersode/README.md
+++ b/contributions/demo/week7-dependency-DevSecOps/ersode/README.md
@@ -1,0 +1,23 @@
+# Assignment Proposal
+
+## Title
+
+Sending Microsoft Azure security advisories to Slack
+
+## Names and KTH ID
+
+- Eric Söderberg (ersode)
+
+## Deadline
+
+Task 3
+
+## Category
+
+Demo
+
+## Description
+
+[Microsoft Azure](https://azure.microsoft.com/en-us/) is one of the largest cloud providers worldwide. One of its services is dedicated to notifying customers when their services are exposed to a security risk, such as if a vulnerability is discovered in its software or infrastructure.
+
+In this demo, I will walk viewers through the process of setting up an [Azure Service Health Alert](https://azure.microsoft.com/en-us/features/service-health/) to alert an [Azure Logic App](https://azure.microsoft.com/en-us/services/logic-apps/), which processes the alert, making it human-readable, before forwarding it to a [Slack](https://slack.com/) server.


### PR DESCRIPTION
# Assignment Proposal

## Title

Sending Microsoft Azure security advisories to Slack

## Names and KTH ID

- Eric Söderberg (ersode)

## Deadline

Task 3

## Category

Demo

## Description

[Microsoft Azure](https://azure.microsoft.com/en-us/) is one of the largest cloud providers worldwide. One of its services is dedicated to notifying customers when their services are exposed to a security risk, such as if a vulnerability is discovered in its software or infrastructure.

In this demo, I will walk viewers through the process of setting up an [Azure Service Health Alert](https://azure.microsoft.com/en-us/features/service-health/) to alert an [Azure Logic App](https://azure.microsoft.com/en-us/services/logic-apps/), which processes the alert, making it human-readable, before forwarding it to a [Slack](https://slack.com/) server.
