### PR TITLE
Automatic weekly recap mail : final submission

### DIFF
--- a/contributions/course-automation/paulinev/README.md
+++ b/contributions/course-automation/paulinev/README.md
@@ -15,7 +15,12 @@ I would create a github action that send a weekly mail that would send a mail wi
 - plan for the next week (arcticles to read according to the readme), when and where are the lectures
 - task done, and next task deadline (for example if the student has done 0 task, it would be the deadline for task 1, if it has aldready done 1 task, it would be the date for deadline 2)
 
-To create my mail I would :
+To create my mail I have :
 - analayze the readme to find the task deadline and the articles to read
 - analysze the calendar ics found there "https://www.kth.se/social/course/DD2482/calendar/ical/?lang=en"
 - use the issue statistics  ( #1607 (Statistics of Student Registrations) for this year for example) to have the number of task done by a student. FOr studennt with no task yet I will try to use canvas API (if I can have acces to it) 
+
+
+## Final submission
+- ![GitHup Repo](https://github.com/paulinev-kth/weekly_recap_mail)
+- ![Marketplace](https://github.com/marketplace/actions/dd2482-weekly-mail)

--- a/contributions/course-automation/paulinev/README.md
+++ b/contributions/course-automation/paulinev/README.md
@@ -21,6 +21,6 @@ To create my mail I have :
 - use the issue statistics  ( #1607 (Statistics of Student Registrations) for this year for example) to have the number of task done by a student. FOr studennt with no task yet I will try to use canvas API (if I can have acces to it) 
 
 
-## Final submission
+== Final submission
 - ![GitHup Repo](https://github.com/paulinev-kth/weekly_recap_mail)
 - ![Marketplace](https://github.com/marketplace/actions/dd2482-weekly-mail)


### PR DESCRIPTION
## Title
Automatic weekly recap mail (https://github.com/KTH/devops-course/pull/1725)
## Names and KTH ID
-  Pauline Vaillant ([paulinev@kth.se](mailto:paulinev@kth.se))

## Deadline
Task 2
## Category
Course automation
## Description

I have created a github action that send a weekly mail that would send a mail with
- plan for the next week (articles to read according to the readme)
-  when and where are the lectures
- task done, and next task deadline (for example if the student has done 1  task, it would be the deadline for task 2, if it has already done 1 task, it would be the date for deadline 3)



