### PR TITLE
Proposal open source - Adding support for conversion to WEBP format to ImgBot

### DIFF
--- a/contributions/open-source/lukasgut-ttle/README.md
+++ b/contributions/open-source/lukasgut-ttle/README.md
@@ -1,0 +1,26 @@
+# Assignment Proposal
+
+## Title
+
+Open-source contribution, adding support for converison to WEBP format
+
+## Names and KTH ID
+
+Lukas Gutenberg (lukasgut@kth.se)
+Tony Le (ttle@kth.se)
+
+## Deadline
+
+Task 4
+
+## Category
+
+Contribution to open-source
+
+## Description
+
+ImgBot (#310) crawls through all of the image files in a GitHub repo and losslessly compresses them. Once it is done, it opens a PR for review and merging. The community is pretty active, it has 893 stars as well as over 1000 commits.
+
+Support for conversion to WEBP format is a feature that is requested in this issue: https://github.com/imgbot/Imgbot/issues/1049
+
+We intend to implement this feature, as well as update the documentation accordingly to properly explain how to enable / disable it.

--- a/contributions/open-source/lukasgut-ttle/README.md
+++ b/contributions/open-source/lukasgut-ttle/README.md
@@ -6,8 +6,8 @@ Open-source contribution, adding support for converison to WEBP format
 
 ## Names and KTH ID
 
-Lukas Gutenberg (lukasgut@kth.se)
-Tony Le (ttle@kth.se)
+- Lukas Gutenberg (lukasgut@kth.se)
+- Tony Le (ttle@kth.se)
 
 ## Deadline
 


### PR DESCRIPTION
# Assignment Proposal

## Title

Open-source contribution, adding support for converison to WEBP format

## Names and KTH ID

- Lukas Gutenberg (lukasgut@kth.se)
- Tony Le (ttle@kth.se)

## Deadline

Task 4

## Category

Contribution to open-source

## Description

ImgBot (#310) crawls through all of the image files in a GitHub repo and losslessly compresses them. Once it is done, it opens a PR for review and merging. The community is pretty active, it has 893 stars as well as over 1000 commits.

Support for conversion to WEBP format is a feature that is requested in this issue: https://github.com/imgbot/Imgbot/issues/1049

We intend to implement this feature, as well as update the documentation accordingly to properly explain how to enable / disable it.