### PR TITLE
Demo proposal: Game Maker chrash resport collection automation 

### DIFF
--- a/contributions/demo/week9-other/libl-svanhol/README.md
+++ b/contributions/demo/week9-other/libl-svanhol/README.md
@@ -1,0 +1,28 @@
+# Assignment Proposal
+
+## Title
+
+Collecting user chrash report in GameMaker
+
+Monitoring chrash report
+
+## Names and KTH ID
+- Linus Below Blomkvist (libl@kth.se)
+- Fredrik Svanholm (svanhol@kth.se)
+
+## Deadline
+
+Task 4
+
+## Category
+
+Demo
+
+## Description
+
+With monitoring of games and webbaplication notification can sent to update the user about a chrash and the causes of it 
+in order to prevent further chrashing.
+
+With the use of GameMakeer
+
+Repository links

--- a/contributions/demo/week9-other/libl-svanhol/README.md
+++ b/contributions/demo/week9-other/libl-svanhol/README.md
@@ -20,9 +20,8 @@ Demo
 
 ## Description
 
-With monitoring of games and webbaplication notification can sent to update the user about a chrash and the causes of it 
-in order to prevent further chrashing.
+GameMaker is a game engine that has been used to create games such as Shovel Knight, Hyper Light Drifter and Katana Zero. 
 
-With the use of GameMakeer
+GameMaker has a default crash report handler that shows basic information about the crash to the user before exiting the game. 
 
-Repository links
+We would like to override and create our own handler that collects the crash report data along with additional platform and user data that then formats it and sends it to a webhosted database (Firebase) that would allow the game developer (us) to automatically collect crash reports from all users playing the game to be able to analyse where and why the game crashes on different platforms.


### PR DESCRIPTION
# Assignment Proposal

## Title

Collecting user chrash report in GameMaker

Monitoring chrash report

## Names and KTH ID
- Linus Below Blomkvist (libl@kth.se)
- Fredrik Svanholm (svanhol@kth.se)

## Deadline

Task 4

## Category

Demo

## Description

GameMaker is a game engine that has been used to create games such as Shovel Knight, Hyper Light Drifter and Katana Zero. 

GameMaker has a default crash report handler that shows basic information about the crash to the user before exiting the game. 

We would like to override and create our own handler that collects the crash report data along with additional platform and user data that then formats it and sends it to a webhosted database (Firebase) that would allow the game developer (us) to automatically collect crash reports from all users playing the game to be able to analyse where and why the game crashes on different platforms.