### PR TITLE
Sort participation table by number of lectures attended

### DIFF
--- a/tools/track_participation.py
+++ b/tools/track_participation.py
@@ -143,8 +143,11 @@ def get_participation_markdown(participation):
     content += "| Index | Student Name | Number of Lectures Attended | Lecture(s) attended |\n"
     content += "|-------|--------------|-------------------|----------------|\n"
 
+    # sort by number of lectures attended
+    sorted_participation = sorted(participation.items(), key=lambda item: len(item[1]), reverse=True)
+
     index = 1
-    for author, lectures in participation.items():
+    for author, lectures in sorted_participation:
         lecture_numbers = [f"L{LECTURE_DATES_TO_NUMBER[lecture]}" for lecture in sorted(lectures)]
         lectures_list = " ".join(map(str, lecture_numbers))
         total_lectures = len(lectures)
@@ -163,8 +166,11 @@ def get_participation_text(participation):
     table = PrettyTable()
     table.field_names = ["Index", "Student Name", "Number of Lectures Attended", "Lecture(s) attended"]
 
+    # sort by number of lectures attended
+    sorted_participation = sorted(participation.items(), key=lambda item: len(item[1]), reverse=True)
+
     index = 1
-    for author, lectures in participation.items():
+    for author, lectures in sorted_participation:
         lecture_numbers = [f"L{LECTURE_DATES_TO_NUMBER[lecture]}" for lecture in sorted(lectures)]
         lectures_list = " ".join(map(str, lecture_numbers))
         total_lectures = len(lectures)


### PR DESCRIPTION
Continuation of #2463, requested by @algomaster99 [here](https://github.com/KTH/devops-course/pull/2463#issuecomment-2347358086). 

This PR modifies `get_participation_text` and `get_participation_markdown` such that the table is sorted (stable) by the number of lectures attended, instead of just by the timestamp of the first comment made by that user.

This also makes the CI job update the issue description (#2370) with a sorted table, as it uses the output from `get_participation_markdown`.

