### PR TITLE
Week 5 presentation proposal

### DIFF
--- a/contributions/presentation/week5/bthiberg-noakj/README.md
+++ b/contributions/presentation/week5/bthiberg-noakj/README.md
@@ -1,0 +1,30 @@
+# Assignment Proposal
+
+## Title
+
+Strimzi - Easy Apache Kafka on Kubernetes
+
+## Names and KTH ID
+
+  - Björn Thiberg (bthiberg@kth.se)
+  - Noak Jönsson (noakj@kth.se)
+
+## Deadline
+
+- Week 5
+
+## Category
+
+- Presentation
+
+## Description
+
+We will present a tool called Strimzi, used for simplifying the process of running the event streaming platform Apache Kafka using Kubernetes. 
+
+Among other things, we'll go over Strimzi's core functionality, what problem it solves, how it is set up and ran and how it fits in to a larger infrastructure and the larger context of DevOps and IaC.
+
+**Relevance**
+
+Strimzi is an example of using IaC to manage complex deployments of infrastructure, Apache Kafka + Kubernetes in this case.
+
+Its "Kubernetes-Native Experience" allows Strimzi to integrate well with e.g. GitOps and other DevOps-y frameworks.


### PR DESCRIPTION
# Assignment Proposal

## Title

Strimzi - Easy Apache Kafka on Kubernetes

## Names and KTH ID

  - Björn Thiberg (bthiberg@kth.se)
  - Noak Jönsson (noakj@kth.se)

## Deadline

- Week 5

## Category

- Presentation

## Description

We will present a tool called Strimzi, used for simplifying the process of running the event streaming platform Apache Kafka using Kubernetes. 

Among other things, we'll go over Strimzi's core functionality, what problem it solves, how it is set up and ran and how it fits in to a larger infrastructure and the larger context of DevOps and IaC.

**Relevance**

Strimzi is an example of using IaC to manage complex deployments of infrastructure, Apache Kafka + Kubernetes in this case.

Its "Kubernetes-Native Experience" allows Strimzi to integrate well with e.g. GitOps and other DevOps-y frameworks.