### PR TITLE
Week 7: Presentation proposal

### DIFF
--- a/contributions/presentation/week7/linussve-daniellw
+++ b/contributions/presentation/week7/linussve-daniellw
@@ -1,0 +1,24 @@
+# Assignment Proposal
+
+## Title
+
+Metrics vs Logging for DevOps Monitoring (Comparing Prometheus and ELK Stack)
+
+## Names and KTH ID
+
+  - Linus Svensson (linussve@kth.se)
+  - Daniel Lai Wikström (daniellw@kth.se)
+  
+## Deadline
+
+- Week 7
+
+## Category
+
+- Presentation
+
+Monitoring is critical in DevOps because it enables the developer to detect issues early, ensure system reliability and performance, as well as provide data for troubleshooting and optimisation. The two types of monitoring, metrics and logs, are both valid options, each with the possibility to be the optimal solution depending on the scenario. To know when to use what type of monitoring, is vastly beneficial for a DevOps engineer. 
+
+**Relevance**
+
+In this presentation we’ll be looking at the tools Prometheus and ELK stack for monitoring. The tools represent two different approaches to observability. ELK stack analyzes log data while Prometheus looks at metrics. We’ll then be comparing the two to determine the types of situation where each tool excels. 


### PR DESCRIPTION
# Assignment Proposal

## Title

Metrics vs Logging for DevOps Monitoring (Comparing Prometheus and ELK Stack)

## Names and KTH ID

  - Linus Svensson (linussve@kth.se)
  - Daniel Lai Wikström (daniellw@kth.se)
  
## Deadline

- Week 7

## Category

- Presentation

Monitoring is critical in DevOps because it enables the developer to detect issues early, ensure system reliability and performance, as well as provide data for troubleshooting and optimisation. The two types of monitoring, metrics and logs, are both valid options, each with the possibility to be the optimal solution depending on the scenario. To know when to use what type of monitoring, is vastly beneficial for a DevOps engineer. 

**Relevance**

In this presentation we’ll be looking at the tools Prometheus and ELK stack for monitoring. The tools represent two different approaches to observability. ELK stack analyzes log data while Prometheus looks at metrics. We’ll then be comparing the two to determine the types of situation where each tool excels.
