### PR TITLE
fix: exclude TAs and Martin from triggering active particpation

### DIFF
--- a/.github/workflows/lecture_participation.yml
+++ b/.github/workflows/lecture_participation.yml
@@ -9,7 +9,11 @@ permissions:
 
 jobs:
   track-participation:
-    if: github.event.issue.number == 2370
+    if: >
+      github.event.issue.number == 2370 &&
+      github.event.comment.author_association != 'COLLABORATOR' &&
+      github.event.comment.author_association != 'OWNER' &&
+      github.event.comment.author_association != 'MEMBER'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The workflow was triggered when I commented. See https://github.com/KTH/devops-course/actions/runs/11259532298. @bjornthiberg was there some bug in the script that we overlooked? Anyhow, the changes that I have proposed should fix it.