### PR TITLE
Check files affected by task contribution Pull Requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**The pull request must both contain a README.md and have description following this template:**
+**The pull request must both contain a README.md and have description following the template below. This README.md must be the only file affected by the PR, and its contents must match the PR description exactly.**
 
 **The README.md file must be located in the directory**:
 

--- a/.github/workflows/check_task.yml
+++ b/.github/workflows/check_task.yml
@@ -3,6 +3,11 @@ name: Check task
 # Controls when the workflow will run
 on:
   pull_request_target:
+    types:
+      - opened
+      - reopened # good to check canvas again to see if eligibility changed
+      - edited # we need to check the new description against the README
+      - synchronize
     branches:
       - 2024
     paths:

--- a/.github/workflows/check_task.yml
+++ b/.github/workflows/check_task.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Check task
 
 # Controls when the workflow will run
@@ -12,8 +10,43 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  check-affected-files:
+    name: Check affected files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+
+      - name: Check affected files
+        env:
+          # get all affected files (created, modified, deleted, etc.)
+          FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+          FILES_COUNT: ${{ steps.changed-files.outputs.all_changed_and_modified_files_count }}
+        run: |
+          for file in "$FILES"; do
+            echo "Info: $file was changed"
+          done
+          if [ "$FILES_COUNT" -ne 1 ]; then
+            echo "Error: More than one file affected ($FILES_COUNT)"
+            exit 1
+          fi
+          if [[ "$FILES" =~ ^contributions\/(executable-tutorial|feedback|open-source)\/[^\/]+\/README\.md$ ]]; then
+            echo "Info: Matches async task"
+          elif [[ "$FILES" =~ ^contributions\/(demo|presentation|scientific-paper)\/week[2-7]\/[^\/]+\/README\.md$ ]]; then
+            echo "Info: Matches sync task"
+          else
+            echo "Error: File in wrong directory ($FILES)"
+            exit 1
+          fi
+
+  check-canvas:
+    name: Check proposal is compatible with previous student task registrations
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check_task.yml
+++ b/.github/workflows/check_task.yml
@@ -80,6 +80,7 @@ jobs:
             echo "Info: PR description matches affected file"
           else
             echo "Error: PR description does not match affected file!"
+            exit 1
           fi
 
   check-canvas:

--- a/.github/workflows/check_task.yml
+++ b/.github/workflows/check_task.yml
@@ -13,6 +13,8 @@ jobs:
   check-affected-files:
     name: Check affected files
     runs-on: ubuntu-latest
+    outputs:
+      affected_file: ${{ steps.check-affected-files.outputs.affected_file }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,6 +25,7 @@ jobs:
         uses: tj-actions/changed-files@v45
 
       - name: Check affected files
+        id: check-affected-files
         env:
           # get all affected files (created, modified, deleted, etc.)
           FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
@@ -42,6 +45,41 @@ jobs:
           else
             echo "Error: File in wrong directory ($FILES)"
             exit 1
+          fi
+
+          echo "affected_file=$FILES" >> "$GITHUB_OUTPUT"
+
+  check-pr-description:
+    name: Check whether Pull Request description matches affected file
+    needs: check-affected-files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install wdiff
+        # we use wdiff (word-diff) instead of plain diff (line-based) to ensure
+        # that we only enforce *content* to be the same rather than specific
+        # file formatting that would otherwise be ignored when the markdown is
+        # rendered. e.g., wdiff allows the README to break lines at col 80 for
+        # readability while still having the PR description without mid-sentence
+        # breaks (since GitHub descriptions don't support them)
+        run: |
+          sudo apt update
+          sudo apt install -y wdiff
+
+      - name: Check PR description
+        env:
+          AFFECTED_FILE: ${{ needs.check-affected-files.outputs.affected_file }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          BODY_FILE="$(mktemp)"
+          echo "$PR_BODY" > $BODY_FILE
+          if wdiff "$AFFECTED_FILE" "$BODY_FILE"; then
+            echo "Info: PR description matches affected file"
+          else
+            echo "Error: PR description does not match affected file!"
           fi
 
   check-canvas:


### PR DESCRIPTION
Fixes #2583 

This pull request checks whether any contributions match the norm of what is expected of a task proposal/submission:

- exactly one file changed, named `README.md` and in a reasonable location; and
- PR description matches the README file (so that reviewers don't need to check both places)