### PR TITLE
Why Netflix Built Spinnaker: Solving Continuous Deployment Challenges

### DIFF
--- a/contributions/presentation/week3/rezahos-ajfr2/README.md
+++ b/contributions/presentation/week3/rezahos-ajfr2/README.md
@@ -1,0 +1,29 @@
+# Assignment Proposal
+
+## Title
+
+Why Netflix Built Spinnaker: Solving Continuous Deployment Challenges
+
+## Names and KTH ID
+
+- Reza Hosseini (rezahos@kth.se)
+- Adam Fridén Rasmussen (ajfr2@kth.se)
+
+## Deadline
+
+Week 3
+
+## Category
+
+Presentation
+
+## Description
+
+We wish to present the story of why Spinnaker was created and how it solved real problems with Continuous Deployment (CD). Netflix(the creator of spinnaker) found that typical CD tools often struggle with fragile pipelines, slow rollouts, and developers fear of breaking production. Existing CD tools couldn’t handle the scale, multi-cloud deployments, and the need for safe rollouts. Leading to the creation of Spinnaker. 
+
+Spinnaker is a Continuous Deployment tool that helps teams release software safely and quickly. It automates rollouts with strategies like canary and blue/green deployments, and can even roll back automatically if something goes wrong.
+
+
+**Relevance**
+
+This presentation connects directly to DevOps and Continuous Deployment. By showing relevant CD challenges, Netflix’s motivation, and how Spinnaker solved them, the audience will understand both the technical and organizational impact of CD tools in modern software engineering.


### PR DESCRIPTION
# Assignment Proposal

## Title

Why Netflix Built Spinnaker: Solving Continuous Deployment Challenges

## Names and KTH ID

- Reza Hosseini (rezahos@kth.se)
- Adam Fridén Rasmussen (ajfr2@kth.se)

## Deadline

Week 3

## Category

Presentation

## Description

We wish to present the story of why Spinnaker was created and how it solved real problems with Continuous Deployment (CD). Netflix(the creator of spinnaker) found that typical CD tools often struggle with fragile pipelines, slow rollouts, and developers fear of breaking production. Existing CD tools couldn’t handle the scale, multi-cloud deployments, and the need for safe rollouts. Leading to the creation of Spinnaker. 

Spinnaker is a Continuous Deployment tool that helps teams release software safely and quickly. It automates rollouts with strategies like canary and blue/green deployments, and can even roll back automatically if something goes wrong.


**Relevance**

This presentation connects directly to DevOps and Continuous Deployment. By showing relevant CD challenges, Netflix’s motivation, and how Spinnaker solved them, the audience will understand both the technical and organizational impact of CD tools in modern software engineering.
