### PR TITLE
Presentation: Coolify: Can a Self-Hosted PaaS Simplify DevOps for Small Teams?

### DIFF
--- a/contributions/presentation/week3/abibr-ismmoh/README.md
+++ b/contributions/presentation/week3/abibr-ismmoh/README.md
@@ -1,0 +1,27 @@
+# Assignment Proposal
+
+## Title
+
+Coolify: Can a Self-Hosted PaaS Simplify DevOps for Small Teams?
+
+## Names and KTH ID
+
+  - Ahmedhadi Bashir (abibr@kth.se)
+  - Ismail Mohammed (ismmoh@kth.se)
+
+## Deadline
+
+- Week 3
+
+## Category
+
+- Presentation
+
+## Description
+
+This presentation explores Coolify, an open-source self-hosted Platform-as-a-Service (PaaS) designed to simplify application deployment and infrastructure management. Running on Docker, Coolify automates Git-based deployments, SSL certificates, secrets handling, and database provisioning. The talk includes a technical deep dive into its architecture and a reflection on the trade-offs between using self-hosted solutions like Coolify versus managed platforms such as Heroku.
+
+
+**Relevance**
+
+Coolify is directly relevant to DevOps because it embodies key principles like Continuous Deployment, Infrastructure as Code, and automation of operational tasks. It shows how small teams can achieve DevOps practices without complex Kubernetes setups or expensive managed services. At the same time, it raises important questions about the balance between simplifying operations and retaining control over infrastructure—an ongoing challenge in modern DevOps practices.


### PR DESCRIPTION
# Assignment Proposal

## Title

Coolify: Can a Self-Hosted PaaS Simplify DevOps for Small Teams?

## Names and KTH ID

  - Ahmedhadi Bashir (abibr@kth.se)
  - Ismail Mohammed (ismmoh@kth.se)

## Deadline

- Week 3

## Category

- Presentation

## Description

This presentation explores Coolify, an open-source self-hosted Platform-as-a-Service (PaaS) designed to simplify application deployment and infrastructure management. Running on Docker, Coolify automates Git-based deployments, SSL certificates, secrets handling, and database provisioning. The talk includes a technical deep dive into its architecture and a reflection on the trade-offs between using self-hosted solutions like Coolify versus managed platforms such as Heroku.


**Relevance**

Coolify is directly relevant to DevOps because it embodies key principles like Continuous Deployment, Infrastructure as Code, and automation of operational tasks. It shows how small teams can achieve DevOps practices without complex Kubernetes setups or expensive managed services. At the same time, it raises important questions about the balance between simplifying operations and retaining control over infrastructure—an ongoing challenge in modern DevOps practices.