### PR TITLE
Week 5 Presentation "ClickOps and how it can hurt IaC through configuration drift"

### DIFF
--- a/contributions/demo/week3/edwinahl-ekanerva/README.md
+++ b/contributions/demo/week3/edwinahl-ekanerva/README.md
@@ -1,0 +1,27 @@
+# Assignment Proposal
+
+## Title
+
+CD Using Elixir/Erland Hot Code Swapping and Github self-hosted Runner
+
+## Names and KTH ID
+
+  - Edwin Ahlstrand (edwinahl@kth.se)
+  - Emil Kanerva (ekanerva@kth.se)
+
+## Deadline
+- Week 3
+
+## Category
+- Demo
+
+## Description
+This demo implements an automated deployment workflow for Elixir using a GitHub self-hosted runner which monitors pushes to the main branch. When new commits are pushed, the runner triggers a workflow that:
+- Pulls the latest code changes from the repository.
+- Builds the new version of the Elixir app.
+- Uses Erlang's hot code swapping to upgrade the app to the new version while still running.
+
+This will be demonstrated through an application which is actively communicating with a server in an uninterrupted manner while it is being updated, showcasing that the changes made to the server immediately become apparent on the client.
+
+**Relevance**
+The project is connected to Week 3 Continuous Deployment/Delivery since it embodiedes core features of DevOps in that topic, mainly automation and continuous integration/deployment. This showcases an alternative to for example Blue/Green deployment where the same speed of deployment can be achieved, but without requiring any extra hardware or systems. 

--- a/contributions/presentation/week5/edwinahl-ekanerva/README.md
+++ b/contributions/presentation/week5/edwinahl-ekanerva/README.md
@@ -1,0 +1,22 @@
+# Assignment Proposal
+
+## Title
+
+ClickOps and how it can hurt IaC through configuration drift
+
+## Names and KTH ID
+
+  - Edwin Ahlstrand (edwinahl@kth.se)
+  - Emil Kanerva (ekanerva@kth.se)
+
+## Deadline
+- Week 5
+
+## Category
+- Presentation
+
+## Description
+This presentation explores how ClickOps can impact IaC with a focus on configuration drift. We will discuss how ClickOps (manual changes) can undermine IaC workflows, cause state mismatches, and introduce operational and securtiy risks. Finally, we will cover strategies for detecting and preventing drift to maintain reliable, automated infrastructure using tools such as Terraform.
+
+**Relevance**
+IaC is a core DevOps practice. However, when teams mix ClickOps with IaC, they are stepping away from core DevOps principles and risking configuration drift. Understanding how manual changes impact automated workflows is crucial for effective DevOps implementations.


### PR DESCRIPTION
# Assignment Proposal

## Title

ClickOps and how it can hurt IaC through configuration drift

## Names and KTH ID

  - Edwin Ahlstrand (edwinahl@kth.se)
  - Emil Kanerva (ekanerva@kth.se)

## Deadline
- Week 5

## Category
- Presentation

## Description
This presentation explores how ClickOps can impact IaC with a focus on configuration drift. We will discuss how ClickOps (manual changes) can undermine IaC workflows, cause state mismatches, and introduce operational and securtiy risks. Finally, we will cover strategies for detecting and preventing drift to maintain reliable, automated infrastructure using tools such as Terraform.

**Relevance**
IaC is a core DevOps practice. However, when teams mix ClickOps with IaC, they are stepping away from core DevOps principles and risking configuration drift. Understanding how manual changes impact automated workflows is crucial for effective DevOps implementations.
