### PR TITLE
Week 5: Presentation - Common Defects in Infrastructure as Code: The "Gang of Eight"

### DIFF
--- a/contributions/presentation/week5/fhsu-bingjiez/README.md
+++ b/contributions/presentation/week5/fhsu-bingjiez/README.md
@@ -1,0 +1,28 @@
+# Assignment Proposal
+
+## Title
+
+Common Defects in Infrastructure as Code: The "Gang of Eight"
+
+## Names and KTH ID
+
+  - Fauzan Helmi Sudaryanto (fhsu@kth.se)
+  - Bingjie Zhao (bingjiez@kth.se)
+
+## Deadline
+
+Week 5
+
+## Category
+
+Presentation
+
+## Description
+
+Infrastructure as Code (IaC) is now widely used in DevOps to manage servers, networks, and cloud resources with scripts. However, IaC scripts are not always perfect. Researchers have found eight common categories of defects in IaC scripts, called the "Gang of Eight". These include problems like hard-coded values, missing dependencies, or weak security practices.
+
+In this presentation, we will first explain why IaC is important in DevOps. Then, we will introduce the eight defect categories with simple examples of code. We will also show how to fix or avoid these problems. Finally, we will reflect on what these defects mean for software teams and how best practices can reduce risks.
+
+**Relevance**
+
+We saw the Preparatory material of Week 5 (Gang of eight: a defect taxonomy for infrastructure as code scripts; http://www.chrisparnin.me/pdf/GangOfEight.pdf).  This topic is relevant because DevOps depends on automation and reliability. If IaC scripts have defects, the whole system can fail or become insecure. By learning about the "Gang of Eight", DevOps engineers can write better scripts and prevent serious problems in real projects.


### PR DESCRIPTION
# Assignment Proposal

## Title

Common Defects in Infrastructure as Code: The "Gang of Eight"

## Names and KTH ID

  - Fauzan Helmi Sudaryanto (fhsu@kth.se)
  - Bingjie Zhao (bingjiez@kth.se)

## Deadline

Week 5

## Category

Presentation

## Description

Infrastructure as Code (IaC) is now widely used in DevOps to manage servers, networks, and cloud resources with scripts. However, IaC scripts are not always perfect. Researchers have found eight common categories of defects in IaC scripts, called the "Gang of Eight". These include problems like hard-coded values, missing dependencies, or weak security practices.

In this presentation, we will first explain why IaC is important in DevOps. Then, we will introduce the eight defect categories with simple examples of code. We will also show how to fix or avoid these problems. Finally, we will reflect on what these defects mean for software teams and how best practices can reduce risks.

**Relevance**

We saw the Preparatory material of Week 5 (Gang of eight: a defect taxonomy for infrastructure as code scripts; http://www.chrisparnin.me/pdf/GangOfEight.pdf).  This topic is relevant because DevOps depends on automation and reliability. If IaC scripts have defects, the whole system can fail or become insecure. By learning about the "Gang of Eight", DevOps engineers can write better scripts and prevent serious problems in real projects.