### PR TITLE
Vagrant: From nothing to Web and DB VM’s with one command

### DIFF
--- a/contributions/demo/week5/ericwer-yvdal/README.md
+++ b/contributions/demo/week5/ericwer-yvdal/README.md
@@ -1,0 +1,26 @@
+# Assignment Proposal
+
+## Title
+
+Vagrant: From nothing to Web and DB VM’s with one command
+
+## Names and KTH ID
+
+- Eric Wernström (ericwer@kth.se)
+- August Yvdal (yvdal@kth.se)
+
+## Deadline
+
+- Week 5
+
+## Category
+
+- Demo
+
+## Description
+
+We will show how Vagrant can quickly set up two virtual machines with a single Vagrantfile and one command. One of the VM’s will run a web server whilst the other one contains a database, with both automatically configured via provisioning scripts. We intend to demonstrate how Vagrant simplifies setup, including installations, networking and config. We will also show that changes can be applied to both machines at the same time.
+
+**Relevance**
+
+The simplification that Infrastructure as Code provides through Vagrant shows how Infrastructure as Code makes setting up servers faster, more consistent, reliable and easier to share. By using a single configuration file to provision multiple virtual machines automatically, everything is automated and repeatable instead of requiring manual installation, configuration, and troubleshooting. This also means that each team member can work in identical environments. These aspects line up with core DevOps principles of automation and collaboration.

--- a/contributions/presentation/week3/ericwer-yvdal/README.md
+++ b/contributions/presentation/week3/ericwer-yvdal/README.md
@@ -2,7 +2,7 @@
 
 ## Title
 
-Automatic Rollback in CI/CD pipelines using Kubernetes Flagger and Prometheus
+The power of canary releases in CD pipelines: Monitoring and Rollback
 
 ## Names and KTH ID
 
@@ -19,8 +19,8 @@ Automatic Rollback in CI/CD pipelines using Kubernetes Flagger and Prometheus
 
 ## Description
 
-We wish to present the process of automated rollback in CD pipelines with canary releases. The process involves monitoring of the canary release which provides metrics for evaluation the performance and stability of a release using a tool like Prometheus. In Kubernetes projects, tools like Kubernetes Flagger can be used to either trigger a rollback or to mark the canary release as stable, making it the new stable version.
+We wish to present the process of automated rollback in CD pipelines with canary releases, focusing on how canary releases can help with validating the stability of new versions in production environments. A canary release is a deployment strategy where a new version is released to only a subset of users, by redirecting their traffic away from the current stable version to a “beta release”. Data like error rates and latency can be collected from the canary release, giving the development team an image of how the version performs under real pressure. The presentation will cover the process of collecting data on the canary, the benefits and downsides of this strategy, and what happens when the canary release is not stable enough. For this, we will bring up the example of such a setup using Prometheus as a monitoring tool, and Kubernetes/Flagger as a method of version rollback.
 
 **Relevance**
 
-Despite CI/CD pipelines often having extensive test suites, it is not guaranteed that said tests are up-to-date and able to catch everything which may go wrong when a change is deployed to production. Therefore it is important to implement safeguards like monitoring and rollback mechanisms. Looking at metrics like HTTP error rates and latency allows the system to detect shaky deployments and to revert back to a knwon stable version. The tools we mention are common choices in projects that are live today. These tools allign nicely with core principles of DevOps like automation.
+Despite CI/CD pipelines often having extensive test suites, it is not guaranteed that said tests are up-to-date and able to catch everything which may go wrong when a change is deployed to production. By using canary releases the production/operations and developer teams get to analyze how new releases work on live users. Automated test suites catch many issues before release but they cannot fully replicate real world conditions. Automated rollback mechanisms, as seen with tools like Prometheus and Flagger in Kubernetes, ensure that if a canary underperforms, the system can quickly return to a stable state without manual intervention. This lines up with principles of DevOps like automation and fast feedback.

--- a/contributions/presentation/week3/ericwer-yvdal/README.md
+++ b/contributions/presentation/week3/ericwer-yvdal/README.md
@@ -1,0 +1,26 @@
+# Assignment Proposal
+
+## Title
+
+Automatic Rollback in CI/CD pipelines using Kubernetes Flagger and Prometheus
+
+## Names and KTH ID
+
+- Eric Wernström (ericwer@kth.se)
+- August Yvdal (yvdal@kth.se)
+
+## Deadline
+
+- Week 3
+
+## Category
+
+- Presentation
+
+## Description
+
+We wish to present the process of automated rollback in CD pipelines with canary releases. The process involves monitoring of the canary release which provides metrics for evaluation the performance and stability of a release using a tool like Prometheus. In Kubernetes projects, tools like Kubernetes Flagger can be used to either trigger a rollback or to mark the canary release as stable, making it the new stable version.
+
+**Relevance**
+
+Despite CI/CD pipelines often having extensive test suites, it is not guaranteed that said tests are up-to-date and able to catch everything which may go wrong when a change is deployed to production. Therefore it is important to implement safeguards like monitoring and rollback mechanisms. Looking at metrics like HTTP error rates and latency allows the system to detect shaky deployments and to revert back to a knwon stable version. The tools we mention are common choices in projects that are live today. These tools allign nicely with core principles of DevOps like automation.


### PR DESCRIPTION
# Assignment Proposal

## Title

Vagrant: From nothing to Web and DB VM’s with one command

## Names and KTH ID

- Eric Wernström (ericwer@kth.se)
- August Yvdal (yvdal@kth.se)

## Deadline

- Week 5

## Category

- Demo

## Description

We will show how Vagrant can quickly set up two virtual machines with a single Vagrantfile and one command. One of the VM’s will run a web server whilst the other one contains a database, with both automatically configured via provisioning scripts. We intend to demonstrate how Vagrant simplifies setup, including installations, networking and config. We will also show that changes can be applied to both machines at the same time.

**Relevance**

The simplification that Infrastructure as Code provides through Vagrant shows how Infrastructure as Code makes setting up servers faster, more consistent, reliable and easier to share. By using a single configuration file to provision multiple virtual machines automatically, everything is automated and repeatable instead of requiring manual installation, configuration, and troubleshooting. This also means that each team member can work in identical environments. These aspects line up with core DevOps principles of automation and collaboration.