### PR TITLE
"A Roadmap for Integrating Sustainability into Software Engineering Education" with a focus on DevOps

### DIFF
--- a/contributions/scientific-paper/week7/fhsu-puta/README.md
+++ b/contributions/scientific-paper/week7/fhsu-puta/README.md
@@ -1,0 +1,28 @@
+# Assignment Proposal
+
+## Title
+
+"A Roadmap for Integrating Sustainability into Software Engineering Education" with a focus on DevOps
+
+## Names and KTH ID
+
+  - Fauzan Helmi Sudaryanto (fhsu@kth.se)
+  - Štěpán Půta (puta@kth.se)
+
+## Deadline
+
+- Week 7
+
+## Category
+
+- Scientific paper
+
+## Description
+
+We would like to present the paper "A Roadmap for Integrating Sustainability into Software Engineering Education", that focuses on identifying the main challenges of adding sustainability into Software Engineering Education. The paper outlines practical strategies to help prepare students to address global crises through sustainable software engineering practices. Because this paper is focused more toward general software engineering, we would also explore sustainable tools, that are more closer related to DevOps, e.g. https://github.com/thegreenwebfoundation/co2.js.
+
+Paper link: https://dl.acm.org/doi/10.1145/3708526
+
+**Relevance**
+
+This paper is related to DevOps because DevOps pipelines and tools offer a direct opportunity to monitor, optimize, and reduce the environmental impact of software systems in deployments.


### PR DESCRIPTION
# Assignment Proposal

## Title

"A Roadmap for Integrating Sustainability into Software Engineering Education" with a focus on DevOps

## Names and KTH ID

  - Fauzan Helmi Sudaryanto (fhsu@kth.se)
  - Štěpán Půta (puta@kth.se)

## Deadline

- Week 7

## Category

- Scientific paper

## Description

We would like to present the paper "A Roadmap for Integrating Sustainability into Software Engineering Education", that focuses on identifying the main challenges of adding sustainability into Software Engineering Education. The paper outlines practical strategies to help prepare students to address global crises through sustainable software engineering practices. Because this paper is focused more toward general software engineering, we would also explore sustainable tools, that are more closer related to DevOps, e.g. https://github.com/thegreenwebfoundation/co2.js.

Paper link: https://dl.acm.org/doi/10.1145/3708526

**Relevance**

This paper is related to DevOps because DevOps pipelines and tools offer a direct opportunity to monitor, optimize, and reduce the environmental impact of software systems in deployments.