### PR TITLE
Update CI branch triggers from 2025 to 2026

### DIFF
--- a/.github/workflows/assignment-statistics.yml
+++ b/.github/workflows/assignment-statistics.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the 2021 branch
   push:
     branches:
-    - "2025"
+    - "2026"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/check_task.yml
+++ b/.github/workflows/check_task.yml
@@ -9,7 +9,7 @@ on:
       - edited # we need to check the new description against the README
       - synchronize
     branches:
-      - 2025
+      - 2026
     paths:
       - contributions/**
 

--- a/.github/workflows/update_criteria.yml
+++ b/.github/workflows/update_criteria.yml
@@ -6,7 +6,7 @@ name: Grading criteria
 on:
   push:
     branches:
-      - 2025
+      - 2026
     paths:
       - 'grading-criteria.md'
 

--- a/.github/workflows/update_task.yml
+++ b/.github/workflows/update_task.yml
@@ -6,7 +6,7 @@ name: Update task
 on:
   push:
     branches:
-      - 2025
+      - 2026
     paths:
       - contributions/**
 


### PR DESCRIPTION
## Summary
- Bumps the `2025` branch trigger to `2026` in `assignment-statistics.yml`, `check_task.yml`, `update_criteria.yml`, and `update_task.yml` — these were still watching last year's branch.
- Points the `ASSIGNMENT_STAT_ISSUE_NUMBER` secret at #2938, the new "Statistics of Student Registrations - 2026" issue (replacing the now-closed #2696 for 2025).

## Test plan
- [ ] Merge and push a change under `contributions/**` on `2026` to confirm `check_task.yml`/`update_task.yml` fire
- [ ] Confirm `assignment-statistics.yml` runs and updates #2938 with stats