### PR TITLE
Replace presentation task with project for 2026

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,9 +10,9 @@ feedback:
   - changed-files:
     - any-glob-to-any-file: 'contributions/feedback/**'
 
-presentation:
+project:
   - changed-files:
-    - any-glob-to-any-file: 'contributions/presentation/**'
+    - any-glob-to-any-file: 'contributions/project/**'
 
 scientific-paper:
   - changed-files:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ _The title of your proposal_
 
 _Selected deadline for the assignment_
 
-_If contribution is a **demo** or **presentation** or **scientific-paper** pick one of the following:_
+_If contribution is a **demo** or **scientific-paper** pick one of the following:_
 - Week 2
 - Week 3
 - Week 4
@@ -38,7 +38,7 @@ _Category of your proposal_
 
 _Pick one of the following:_
 - Demo
-- Presentation
+- Project
 - Executable tutorial
 - Scientific paper
 - Open source

--- a/.github/workflows/check_task.yml
+++ b/.github/workflows/check_task.yml
@@ -43,9 +43,9 @@ jobs:
             echo "Error: More than one file affected ($FILES_COUNT)"
             exit 1
           fi
-          if [[ "$FILES" =~ ^contributions\/(executable-tutorial|feedback|open-source)\/[^\/]+\/README\.md$ ]]; then
+          if [[ "$FILES" =~ ^contributions\/(executable-tutorial|feedback|open-source|project)\/[^\/]+\/README\.md$ ]]; then
             echo "Info: Matches async task"
-          elif [[ "$FILES" =~ ^contributions\/(demo|presentation|scientific-paper)\/week[2-7]\/[^\/]+\/README\.md$ ]]; then
+          elif [[ "$FILES" =~ ^contributions\/(demo|scientific-paper)\/week[2-7]\/[^\/]+\/README\.md$ ]]; then
             echo "Info: Matches sync task"
           else
             echo "Error: File in wrong directory ($FILES)"


### PR DESCRIPTION
2026 replaced the "presentation" task with "project". Updates \`check_task.yml\`'s path regex, \`labeler.yml\`, and the PR template to match — project submissions were failing \`check-affected-files\` with "wrong directory".

Companion: KTH/github-canvas-integration-devops#7