### PR TITLE
TEMP: point update-criteria at fork fix branch to verify Canvas sync

### DIFF
--- a/.github/workflows/update_criteria.yml
+++ b/.github/workflows/update_criteria.yml
@@ -23,10 +23,13 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: 'Get tools'
+        # TEMPORARY: pointed at the fork/branch with the fixes
+        # (KTH/github-canvas-integration-devops#7) to verify them before
+        # someone with access merges to main. Revert once that PR merges.
         uses: actions/checkout@v2.3.4
         with:
-          repository: KTH/github-canvas-integration-devops
-          ref: main
+          repository: algomaster99/github-canvas-integration-devops
+          ref: fix/replace-presentation-with-project
           path: canvas-code
 
      # Setup Python

--- a/grading-criteria.md
+++ b/grading-criteria.md
@@ -143,3 +143,4 @@ To pass, you must have at least 7 "yes".
 
 
 
+


### PR DESCRIPTION
## Summary
- Mirrors the existing TEMP override on `check_task_canvas.yml` (#2944): points `update_criteria.yml`'s "Get tools" checkout at `algomaster99/github-canvas-integration-devops@fix/replace-presentation-with-project` (upstream PR [KTH/github-canvas-integration-devops#7](https://github.com/KTH/github-canvas-integration-devops/pull/7)) instead of `main`.
- `main`'s `update_grading.py::parse_criteria()` crashes with `IndexError: list index out of range` on the `## Project` section (it has no criteria table, unlike the other sections), which has caused the `Grading criteria` workflow to fail on every push to `grading-criteria.md` since #2928 — meaning Canvas has never had its 2026 group categories created (confirmed via `check_task_canvas.yml` on #2945 logging `CANVAS_GROUPS_SET {}`).
- The fork branch skips sections without a full criteria table (like `Project`) instead of crashing, per team decision to skip Project for now.
- Second commit is a no-op trailing-newline touch to `grading-criteria.md`, since `update_criteria.yml` only triggers on push to `2026` when that file changes — needed to actually retrigger the workflow and verify the fix against real Canvas.

## Test plan
- [ ] Merge and confirm the `Grading criteria` workflow run succeeds (no `IndexError`)
- [ ] Confirm Canvas group categories exist for Demos, Scientific Papers, Executable Tutorial, Open-Source Contribution, Feedback (Project intentionally skipped)
- [ ] Re-run `check_task_canvas.yml` on an open scientific-paper PR (e.g. #2945) and confirm `CANVAS_GROUPS_SET` is no longer empty
- [ ] Once [KTH/github-canvas-integration-devops#7](https://github.com/KTH/github-canvas-integration-devops/pull/7) merges to `main`, revert this TEMP commit (and the matching one from #2944) to point both workflows back at `main`