### PR TITLE
Drop stale --issue arg

### DIFF
--- a/.github/workflows/update_criteria.yml
+++ b/.github/workflows/update_criteria.yml
@@ -51,4 +51,4 @@ jobs:
           GH_REPO_FULLNAME: ${{ secrets.GH_REPO_FULLNAME }}
         run: |
           export PYTHONPATH="$PWD/canvas-code/utils"
-          python ./canvas-code/update_grading.py --issue vladomitrovic
+          python ./canvas-code/update_grading.py

--- a/grading-criteria.md
+++ b/grading-criteria.md
@@ -144,3 +144,4 @@ To pass, you must have at least 7 "yes".
 
 
 
+


### PR DESCRIPTION
- Drops the now-unrecognized `--issue vladomitrovic` arg (removed in the fork fix, KTH/github-canvas-integration-devops#7)
- Trivial no-op touch to `grading-criteria.md` to retrigger the Canvas sync workflow