### PR TITLE
TEMP: point update-task at fork fix branch

### DIFF
--- a/.github/workflows/update_task.yml
+++ b/.github/workflows/update_task.yml
@@ -23,10 +23,13 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: 'Get tools'
+        # TEMPORARY: pointed at the fork/branch with the fixes
+        # (KTH/github-canvas-integration-devops#7) to verify them before
+        # someone with access merges to main. Revert once that PR merges.
         uses: actions/checkout@v2.3.4
         with:
-          repository: KTH/github-canvas-integration-devops
-          ref: main
+          repository: algomaster99/github-canvas-integration-devops
+          ref: fix/replace-presentation-with-project
           path: canvas-code
 
      # Setup Python


### PR DESCRIPTION
- Mirrors the TEMP overrides already on check_task_canvas.yml (#2944) and update_criteria.yml (#2947)
- main's update_task.py crashes with KeyError: 'Presentations' on any contributions/** push, since Canvas no longer has that category (replaced by Project)
- Revert once KTH/github-canvas-integration-devops#7 merges to main